### PR TITLE
Update react-resizable.css

### DIFF
--- a/src/renderer/components/react-resizable.css
+++ b/src/renderer/components/react-resizable.css
@@ -11,6 +11,7 @@
     https://github.com/STRML/react-resizable/issues/6
    */
   width: 100% !important;
+  max-width: 100%; /* removes scroll bar in windows version */
 }
 
 .react-resizable-ew-resize {


### PR DESCRIPTION

![removes scroll bar](https://cloud.githubusercontent.com/assets/3843423/13127589/39c0ae24-d59e-11e5-8b08-80943dfd45b3.png)
![scrollbars](https://cloud.githubusercontent.com/assets/3843423/13127628/69ae190a-d59e-11e5-8cdb-4dc9f0ddac91.png)


Removes scroll bar at bottom of sidebar ResizableBox.