### PR TITLE
Force result in row be always string

### DIFF
--- a/src/renderer/components/query-result-table.jsx
+++ b/src/renderer/components/query-result-table.jsx
@@ -56,7 +56,7 @@ export default class QueryResultTable extends Component {
       return (
         <tr key={index}>
           {columnNames.map(name => {
-            return <td key={name}>{row[name]}</td>;
+            return <td key={name}>{row[name].toString()}</td>;
           })}
         </tr>
       );


### PR DESCRIPTION
For boolean make sense to be always string...

**So it will looks like:**

![image](https://cloud.githubusercontent.com/assets/46822/13931166/d91e8cce-ef80-11e5-88a4-9787781f53ba.png)

**Before it was showing:**

![image](https://cloud.githubusercontent.com/assets/46822/13931195/fdd638b4-ef80-11e5-825e-d0e96ee01283.png)
