### PR TITLE
Downgrade electron to last version where handling db error connection works

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "denodeify": "^1.2.1",
     "electron-builder": "^2.8.3",
     "electron-packager": "^5.2.1",
-    "electron-prebuilt": "^0.37.3",
+    "electron-prebuilt": "~0.36.12",
     "eslint": "^1.7.3",
     "eslint-config-airbnb": "^0.1.0",
     "eslint-plugin-react": "^3.15.0",


### PR DESCRIPTION
There's a bug when using electron version 0.37.x . If you try to connect to saved connection that is not up at the moment and connection refuses, it goes into an infinite load window instead of returning to server management with error connection message.

For example, I shut down postgresql client and tried to connect to previously saved postgresql database connection. Instead of normally handled error I got following:

![infinite_loading](https://cloud.githubusercontent.com/assets/8470710/14276701/1c6ac6d2-fb20-11e5-8608-28350998b199.png)

As you can see CONNECTION_FAILURE action was not fired up, although it showed up in a console that connection refused. `Connection error {"code":"ECONNREFUSED"...} `
After a minute or so, whole window was blank.

Since the bug showed up after last commit, I tried to reconstruct it with several electron versions and found out its not working with electron 0.37.x . Furthermore, I see a lot of raised issues regarding version 0.37 or higher, so I would wait a bit with a upgrade before more stable patch comes.


