### PR TITLE
Fixes #105

### DIFF
--- a/src/renderer/actions/connections.js
+++ b/src/renderer/actions/connections.js
@@ -79,7 +79,10 @@ export function connect (id, databaseName, reconnecting = false) {
       if (dbConn) {
         dbConn.disconnect();
       }
-      this.disconnect();
+      const currentConn = getState().connections;
+      if (!currentConn.databases.length) {
+        this.disconnect();
+      }
     }
   };
 }

--- a/src/renderer/actions/connections.js
+++ b/src/renderer/actions/connections.js
@@ -79,6 +79,7 @@ export function connect (id, databaseName, reconnecting = false) {
       if (dbConn) {
         dbConn.disconnect();
       }
+      this.disconnect();
     }
   };
 }


### PR DESCRIPTION
Resolved issue #105 . Thing was that `serverSession` was still hanging on unsuccessful connection, so if you switched between different servers and previous one had an error connection, same error was returned.