### PR TITLE
Fixes #109 - Query box now resizes well

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "react-ace": "^2.8.0",
     "react-dom": "^0.14.3",
     "react-redux": "^4.0.1",
-    "react-resizable": "^1.0.1",
+    "react-resizable": "^1.3.2",
     "react-router": "^1.0.2",
     "react-select": "^0.9.1",
     "react-tabs": "^0.5.1",

--- a/src/renderer/components/query.jsx
+++ b/src/renderer/components/query.jsx
@@ -50,6 +50,10 @@ export default class Query extends Component {
     this.setState({ infoModalVisible: true });
   }
 
+  onQueryBoxResize(width, height) {
+    this.refs.queryBoxTextarea.editor.resize();
+  }
+
   render() {
     const { client, query, onCopyToClipboardClick, onSQLChange } = this.props;
     const infos = INFOS[client];
@@ -57,7 +61,11 @@ export default class Query extends Component {
     return (
       <div>
         <div>
-          <ResizableBox className="react-resizable react-resizable-se-resize ui segment" height={200} width={500}>
+          <ResizableBox
+            className="react-resizable react-resizable-se-resize ui segment"
+            height={200}
+            width={500}
+            onResize={::this.onQueryBoxResize}>
             <AceEditor
               mode="sql"
               theme="github"


### PR DESCRIPTION
Thing was that ace editor triggered its resize method automatically only on window resize so it had to be invoked  manually. It's called now on ResizeableBox resize.

Seems that `onResize` method wasn't available in previous `react-resizable` version so I updated `package.json` (I also tried using Resizeable directly but I had other troubles with that). So you'll have to do `npm install` for this to work.