### PR TITLE
Fix typos

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -91,7 +91,7 @@ const TASKS = [
 /**
  * Build browser code with babel
  */
-async function buildBrowserCode () {
+async function buildBrowserCode() {
   const browserBuildPath = join(BUILD_PATH, 'browser');
   return denodeify(exec).call(exec, `babel ./src/browser -d ${browserBuildPath}`, { cwd: ROOT_PATH });
 }

--- a/src/renderer/components/database-list-item.jsx
+++ b/src/renderer/components/database-list-item.jsx
@@ -63,7 +63,7 @@ export default class DatabaseListItem extends Component {
         <i className="grid database icon"></i>
         {this.renderCollapseButton()}
         <span style={STYLE.database}
-          title="Click twich to connect or open new query"
+          title="Click twice to connect or open new query"
           onDoubleClick={() => onSelectDatabase(database)}>
           {database.name}
         </span>


### PR DESCRIPTION
Fix typo in `database-list.jsx` (title shown when hovering over database) and annoying eslint error in `build .js` script (_space-before-function-parentheses_).