### PR TITLE
Fixes #111

### DIFF
--- a/src/renderer/components/query-result-table.jsx
+++ b/src/renderer/components/query-result-table.jsx
@@ -52,10 +52,9 @@ export default class QueryResultTable extends Component {
     }
 
     return rowsValuesToString(rows).map((row, index) => {
-      const columnNames = Object.keys(row);
       return (
         <tr key={index}>
-          {columnNames.map(name => {
+          {fields.map(({ name }) => {
             return <td key={name}>{row[name]}</td>;
           })}
         </tr>


### PR DESCRIPTION
Spent more time debugging this than fixing the code :smile: 

Thing was that attributes in JSON can be mixed up because it is, by definition, unordered structure. I still don't know the reason why this happened when there was more than 15 attributes in our case, but it did. So instead of depending on keys order in JSON (using `Object.keys()`), I changed it to use fields array received as a function parameter. It works now as expected! 