### PR TITLE
Add default port when choose database

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "csv-stringify": "0.0.8",
     "debug": "^2.2.0",
     "react-paginate": "^0.5.0",
-    "sqlectron-core": "^3.2.0"
+    "sqlectron-core": "^3.3.0"
   },
   "devDependencies": {
     "autoprefixer-loader": "^3.1.0",

--- a/src/renderer/components/server-modal-form.jsx
+++ b/src/renderer/components/server-modal-form.jsx
@@ -71,7 +71,16 @@ export default class ServerModalForm extends Component {
   }
 
   onSaveClick() {
-    this.props.onSaveClick(this.mapStateToServer(this.state));
+    const data = {...this.state};
+    if (data.defaultPort) {
+      if (data.port === undefined) {
+        data.port = data.defaultPort;
+      }
+
+      delete data.defaultPort;
+    }
+
+    this.props.onSaveClick(this.mapStateToServer(data));
   }
 
   onRemoveCancelClick() {
@@ -136,7 +145,7 @@ export default class ServerModalForm extends Component {
 
     const clientConfig = CLIENTS.find(entry => entry.value === client);
     if (clientConfig && clientConfig.defaultPort) {
-      this.setState({ port: clientConfig.defaultPort });
+      this.setState({ defaultPort: clientConfig.defaultPort });
     }
   }
 
@@ -242,7 +251,7 @@ export default class ServerModalForm extends Component {
                     name="port"
                     maxLength="5"
                     placeholder="Port"
-                    value={this.state.port}
+                    value={this.state.port || this.state.defaultPort}
                     onChange={::this.handleChange}
                     disabled={this.state.socketPath} />
                 </div>

--- a/src/renderer/components/server-modal-form.jsx
+++ b/src/renderer/components/server-modal-form.jsx
@@ -13,6 +13,7 @@ const CLIENTS = sqlectron.db.CLIENTS.map(dbClient => ({
   value: dbClient.key,
   logo: require(`./server-db-client-${dbClient.key}.png`),
   label: dbClient.name,
+  defaultPort: dbClient.defaultPort,
 }));
 
 
@@ -130,6 +131,15 @@ export default class ServerModalForm extends Component {
     return hasError ? 'error' : '';
   }
 
+  handleOnClientChange(client) {
+    this.setState({ client });
+
+    const clientConfig = CLIENTS.find(entry => entry.value === client);
+    if (clientConfig && clientConfig.defaultPort) {
+      this.setState({ port: clientConfig.defaultPort });
+    }
+  }
+
   handleChange(event) {
     const newState = {};
     const { target } = event;
@@ -199,7 +209,7 @@ export default class ServerModalForm extends Component {
                   name="client"
                   placeholder="Select"
                   options={CLIENTS}
-                  onChange={client => this.setState({ client })}
+                  onChange={::this.handleOnClientChange}
                   optionRenderer={this.renderClientItem}
                   valueRenderer={this.renderClientItem}
                   value={this.state.client} />


### PR DESCRIPTION
This feature auto fill the port when choose one database...

We can not merge it yet as it depends of generate a tag for https://github.com/sqlectron/sqlectron-core/pull/12

I'll just leave it open to review code and once we generate a tag for  sqlectron-core, i can bump the https://github.com/sqlectron/sqlectron-gui/blob/master/package.json#L51 dependency