### PR TITLE
Add query autocompletion

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "minimist": "^1.2.0",
     "node-sass": "^3.4.2",
     "react": "^0.14.8",
-    "react-ace": "^2.8.0",
+    "react-ace": "3.3.0",
     "react-addons-create-fragment": "^0.14.8",
     "react-dom": "^0.14.3",
     "react-paginate": "^0.5.0",

--- a/src/renderer/actions/queries.js
+++ b/src/renderer/actions/queries.js
@@ -66,9 +66,24 @@ export function executeDefaultSelectQueryIfNeeded (database, table) {
   };
 }
 
+export function updateQueryIfNeeded (query) {
+  return (dispatch, getState) => {
+    if (shouldUpdateQuery(query, getState())) {
+      return dispatch(updateQuery(query));
+    }
+  };
+}
 
-export function updateQuery (query) {
+function updateQuery (query) {
   return { type: UPDATE_QUERY, query };
+}
+
+function shouldUpdateQuery (query, state) {
+  const currentQuery = getCurrentQuery(state);
+  if (!currentQuery) return true;
+  if (currentQuery.isExecuting) return false;
+  if (query === currentQuery.query) return false;
+  return true;
 }
 
 

--- a/src/renderer/components/query.jsx
+++ b/src/renderer/components/query.jsx
@@ -3,6 +3,7 @@ import { debounce } from 'lodash';
 import AceEditor from 'react-ace';
 import 'brace/mode/sql';
 import 'brace/theme/github';
+import 'brace/ext/language_tools';
 import QueryResult from './query-result.jsx';
 import ServerDBClientInfoModal from './server-db-client-info-modal.jsx';
 
@@ -77,6 +78,8 @@ export default class Query extends Component {
               showPrintMargin={false}
               editorProps={{$blockScrolling: Infinity}}
               onChange={debounce(onSQLChange, 100)}
+              enableBasicAutocompletion={true}
+              enableLiveAutocompletion={true}
               />
           </ResizableBox>
           <div className="ui secondary menu" style={{marginTop: 0}}>

--- a/src/renderer/containers/query-browser.jsx
+++ b/src/renderer/containers/query-browser.jsx
@@ -120,7 +120,7 @@ class QueryBrowserContainer extends Component {
   }
 
   onSQLChange (sqlQuery) {
-    this.props.dispatch(QueryActions.updateQuery(sqlQuery));
+    this.props.dispatch(QueryActions.updateQueryIfNeeded(sqlQuery));
   }
 
   onFilterChange (value) {


### PR DESCRIPTION
So I took some time today to figure this out. First off, if we do not plan to use autocomplete, react-ace =< 2.8.0 should be used, because upgrading to ^3.x.x causes some [problems](https://github.com/securingsincity/react-ace/issues/95). After some debugging and fixing unpredicted behavior, here it is - simple but neat autocompletion! It completes SQL keyword and words user recently typed (that would be column and table names in most of the cases I guess).

Thou adding autocomplete was a few lines of code, there were some unexpected behavior issues. `onChange` event on AceEditor now fires more often although string remains the same, which caused infinite number of `UPDATE_QUERY` actions. That's why I had to add [this](https://github.com/BornaP/sqlectron-gui/commit/55f5894a0f261cfcf3a544a3df30da016bf4e1be#diff-236a63be919fef1cdbb6ed49da761adeR69).  For some reason, I had difficulties with react-ace v3.4.0, autocomplete only worked for first word and was closing automatically after new `UPDATE_QUERY` action.  It works fine with 3.3.0 so that's why it's listed [explicitly](https://github.com/BornaP/sqlectron-gui/commit/55f5894a0f261cfcf3a544a3df30da016bf4e1be#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R70).

Before this is merged, I'll try if array of items (tables, columns) can be injected in autocompletion list. @maxcnunes @krolow please test it locally if it works on your machines as well! :smiley: 

Btw. Seem's that guys from WagonHQ (commercial version of our app :P) have extended ace with their custom autocomplete. [Link](https://www.wagonhq.com/blog/engineering-at-wagon)

