### PR TITLE
#125 objects sql definitions

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -20,6 +20,6 @@
     "babel-core": "^5.8.29",
     "babel-runtime": "^5.8.29",
     "debug": "^2.2.0",
-    "sqlectron-core": "^3.5.0"
+    "sqlectron-core": "^3.6.0"
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -20,6 +20,6 @@
     "babel-core": "^5.8.29",
     "babel-runtime": "^5.8.29",
     "debug": "^2.2.0",
-    "sqlectron-core": "^3.4.0"
+    "sqlectron-core": "^3.5.0"
   }
 }

--- a/src/renderer/actions/sqlscripts.js
+++ b/src/renderer/actions/sqlscripts.js
@@ -1,0 +1,157 @@
+import { getDBConnByName } from './connections';
+import { updateQueryIfNeeded } from './queries';
+
+
+export const GET_SCRIPT_REQUEST = 'GET_SCRIPT_REQUEST';
+export const GET_SCRIPT_SUCCESS = 'GET_SCRIPT_SUCCESS';
+export const GET_SCRIPT_FAILURE = 'GET_SCRIPT_FAILURE';
+
+
+export function getTableCreateScriptIfNeeded (database, table) {
+  const scriptType = 'CREATE';
+  return (dispatch, getState) => {
+    if (shouldFetchScript(getState(), database, table, scriptType)) {
+      return dispatch(getTableCreateScript(database, table, scriptType));
+    }
+  };
+}
+
+export function getTableSelectScriptIfNeeded (database, table) {
+  const scriptType = 'SELECT';
+  return (dispatch, getState) => {
+    if (shouldFetchScript(getState(), database, table, scriptType)) {
+      return dispatch(getTableSelectScript(database, table, scriptType));
+    }
+  };
+}
+
+export function getTableInsertScriptIfNeeded (database, table) {
+  const scriptType = 'INSERT';
+  return (dispatch, getState) => {
+    if (shouldFetchScript(getState(), database, table, scriptType)) {
+      return dispatch(getTableInsertScript(database, table, scriptType));
+    }
+  };
+}
+
+export function getTableUpdateScriptIfNeeded (database, table) {
+  const scriptType = 'UPDATE';
+  return (dispatch, getState) => {
+    if (shouldFetchScript(getState(), database, table, scriptType)) {
+      return dispatch(getTableUpdateScript(database, table, scriptType));
+    }
+  };
+}
+
+export function getTableDeleteScriptIfNeeded (database, table) {
+  const scriptType = 'DELETE';
+  return (dispatch, getState) => {
+    if (shouldFetchScript(getState(), database, table, scriptType)) {
+      return dispatch(getTableDeleteScript(database, table, scriptType));
+    }
+  };
+}
+
+export function getViewCreateScriptIfNeeded (database, view) {
+  const scriptType = 'CREATE';
+  return (dispatch, getState) => {
+    if (shouldFetchScript(getState(), database, view, scriptType)) {
+      return dispatch(getViewCreateScript(database, view, scriptType));
+    }
+  };
+}
+
+function shouldFetchScript (state, database, table, scriptType) {
+  const scripts = state.sqlscripts;
+  if (!scripts) return true;
+  if (scripts.isFetching) return false;
+  if (!scripts.scriptsByObject[database]) return true;
+  if (!scripts.scriptsByObject[database][table]) return true;
+  if (!scripts.scriptsByObject[database][table][scriptType]) return true;
+  return scripts.didInvalidate;
+}
+
+
+function getTableCreateScript (database, table, scriptType) {
+  return async (dispatch) => {
+    dispatch({ type: GET_SCRIPT_REQUEST, database, table, scriptType });
+    try {
+      const dbConn = getDBConnByName(database);
+      const [script] = await dbConn.getTableCreateScript(table);
+      dispatch({ type: GET_SCRIPT_SUCCESS, database, table, script, scriptType });
+      dispatch(updateQueryIfNeeded(script));
+    } catch (error) {
+      dispatch({ type: GET_SCRIPT_FAILURE, error });
+    }
+  };
+}
+
+function getTableSelectScript (database, table, scriptType) {
+  return async (dispatch) => {
+    dispatch({ type: GET_SCRIPT_REQUEST, database, table, scriptType });
+    try {
+      const dbConn = getDBConnByName(database);
+      const script = await dbConn.getTableSelectScript(table);
+      dispatch({ type: GET_SCRIPT_SUCCESS, database, table, script, scriptType });
+      dispatch(updateQueryIfNeeded(script));
+    } catch (error) {
+      dispatch({ type: GET_SCRIPT_FAILURE, error });
+    }
+  };
+}
+
+function getTableInsertScript (database, table, scriptType) {
+  return async (dispatch) => {
+    dispatch({ type: GET_SCRIPT_REQUEST, database, table, scriptType });
+    try {
+      const dbConn = getDBConnByName(database);
+      const script = await dbConn.getTableInsertScript(table);
+      dispatch({ type: GET_SCRIPT_SUCCESS, database, table, script, scriptType });
+      dispatch(updateQueryIfNeeded(script));
+    } catch (error) {
+      dispatch({ type: GET_SCRIPT_FAILURE, error });
+    }
+  };
+}
+
+function getTableUpdateScript (database, table, scriptType) {
+  return async (dispatch) => {
+    dispatch({ type: GET_SCRIPT_REQUEST, database, table, scriptType });
+    try {
+      const dbConn = getDBConnByName(database);
+      const script = await dbConn.getTableUpdateScript(table);
+      dispatch({ type: GET_SCRIPT_SUCCESS, database, table, script, scriptType });
+      dispatch(updateQueryIfNeeded(script));
+    } catch (error) {
+      dispatch({ type: GET_SCRIPT_FAILURE, error });
+    }
+  };
+}
+
+function getTableDeleteScript (database, table, scriptType) {
+  return async (dispatch) => {
+    dispatch({ type: GET_SCRIPT_REQUEST, database, table, scriptType });
+    try {
+      const dbConn = getDBConnByName(database);
+      const script = await dbConn.getTableDeleteScript(table);
+      dispatch({ type: GET_SCRIPT_SUCCESS, database, table, script, scriptType });
+      dispatch(updateQueryIfNeeded(script));
+    } catch (error) {
+      dispatch({ type: GET_SCRIPT_FAILURE, error });
+    }
+  };
+}
+
+function getViewCreateScript (database, table, scriptType) {
+  return async (dispatch) => {
+    dispatch({ type: GET_SCRIPT_REQUEST, database, table, scriptType });
+    try {
+      const dbConn = getDBConnByName(database);
+      const [script] = await dbConn.getViewCreateScript(table);
+      dispatch({ type: GET_SCRIPT_SUCCESS, database, table, script, scriptType });
+      dispatch(updateQueryIfNeeded(script));
+    } catch (error) {
+      dispatch({ type: GET_SCRIPT_FAILURE, error });
+    }
+  };
+}

--- a/src/renderer/actions/sqlscripts.js
+++ b/src/renderer/actions/sqlscripts.js
@@ -7,56 +7,10 @@ export const GET_SCRIPT_SUCCESS = 'GET_SCRIPT_SUCCESS';
 export const GET_SCRIPT_FAILURE = 'GET_SCRIPT_FAILURE';
 
 
-export function getTableCreateScriptIfNeeded (database, table) {
-  const scriptType = 'CREATE';
+export function getSQLScriptIfNeeded(database, table, actionType, objectType) {
   return (dispatch, getState) => {
-    if (shouldFetchScript(getState(), database, table, scriptType)) {
-      return dispatch(getTableCreateScript(database, table, scriptType));
-    }
-  };
-}
-
-export function getTableSelectScriptIfNeeded (database, table) {
-  const scriptType = 'SELECT';
-  return (dispatch, getState) => {
-    if (shouldFetchScript(getState(), database, table, scriptType)) {
-      return dispatch(getTableSelectScript(database, table, scriptType));
-    }
-  };
-}
-
-export function getTableInsertScriptIfNeeded (database, table) {
-  const scriptType = 'INSERT';
-  return (dispatch, getState) => {
-    if (shouldFetchScript(getState(), database, table, scriptType)) {
-      return dispatch(getTableInsertScript(database, table, scriptType));
-    }
-  };
-}
-
-export function getTableUpdateScriptIfNeeded (database, table) {
-  const scriptType = 'UPDATE';
-  return (dispatch, getState) => {
-    if (shouldFetchScript(getState(), database, table, scriptType)) {
-      return dispatch(getTableUpdateScript(database, table, scriptType));
-    }
-  };
-}
-
-export function getTableDeleteScriptIfNeeded (database, table) {
-  const scriptType = 'DELETE';
-  return (dispatch, getState) => {
-    if (shouldFetchScript(getState(), database, table, scriptType)) {
-      return dispatch(getTableDeleteScript(database, table, scriptType));
-    }
-  };
-}
-
-export function getViewCreateScriptIfNeeded (database, view) {
-  const scriptType = 'CREATE';
-  return (dispatch, getState) => {
-    if (shouldFetchScript(getState(), database, view, scriptType)) {
-      return dispatch(getViewCreateScript(database, view, scriptType));
+    if (shouldFetchScript(getState(), database, table, actionType)) {
+      return dispatch(getSQLScript(database, table, actionType, objectType));
     }
   };
 }
@@ -72,83 +26,26 @@ function shouldFetchScript (state, database, table, scriptType) {
 }
 
 
-function getTableCreateScript (database, table, scriptType) {
+function getSQLScript (database, table, actionType, objectType) {
   return async (dispatch) => {
-    dispatch({ type: GET_SCRIPT_REQUEST, database, table, scriptType });
+    dispatch({ type: GET_SCRIPT_REQUEST, database, table, actionType, objectType });
     try {
       const dbConn = getDBConnByName(database);
-      const [script] = await dbConn.getTableCreateScript(table);
-      dispatch({ type: GET_SCRIPT_SUCCESS, database, table, script, scriptType });
-      dispatch(updateQueryIfNeeded(script));
-    } catch (error) {
-      dispatch({ type: GET_SCRIPT_FAILURE, error });
-    }
-  };
-}
-
-function getTableSelectScript (database, table, scriptType) {
-  return async (dispatch) => {
-    dispatch({ type: GET_SCRIPT_REQUEST, database, table, scriptType });
-    try {
-      const dbConn = getDBConnByName(database);
-      const script = await dbConn.getTableSelectScript(table);
-      dispatch({ type: GET_SCRIPT_SUCCESS, database, table, script, scriptType });
-      dispatch(updateQueryIfNeeded(script));
-    } catch (error) {
-      dispatch({ type: GET_SCRIPT_FAILURE, error });
-    }
-  };
-}
-
-function getTableInsertScript (database, table, scriptType) {
-  return async (dispatch) => {
-    dispatch({ type: GET_SCRIPT_REQUEST, database, table, scriptType });
-    try {
-      const dbConn = getDBConnByName(database);
-      const script = await dbConn.getTableInsertScript(table);
-      dispatch({ type: GET_SCRIPT_SUCCESS, database, table, script, scriptType });
-      dispatch(updateQueryIfNeeded(script));
-    } catch (error) {
-      dispatch({ type: GET_SCRIPT_FAILURE, error });
-    }
-  };
-}
-
-function getTableUpdateScript (database, table, scriptType) {
-  return async (dispatch) => {
-    dispatch({ type: GET_SCRIPT_REQUEST, database, table, scriptType });
-    try {
-      const dbConn = getDBConnByName(database);
-      const script = await dbConn.getTableUpdateScript(table);
-      dispatch({ type: GET_SCRIPT_SUCCESS, database, table, script, scriptType });
-      dispatch(updateQueryIfNeeded(script));
-    } catch (error) {
-      dispatch({ type: GET_SCRIPT_FAILURE, error });
-    }
-  };
-}
-
-function getTableDeleteScript (database, table, scriptType) {
-  return async (dispatch) => {
-    dispatch({ type: GET_SCRIPT_REQUEST, database, table, scriptType });
-    try {
-      const dbConn = getDBConnByName(database);
-      const script = await dbConn.getTableDeleteScript(table);
-      dispatch({ type: GET_SCRIPT_SUCCESS, database, table, script, scriptType });
-      dispatch(updateQueryIfNeeded(script));
-    } catch (error) {
-      dispatch({ type: GET_SCRIPT_FAILURE, error });
-    }
-  };
-}
-
-function getViewCreateScript (database, table, scriptType) {
-  return async (dispatch) => {
-    dispatch({ type: GET_SCRIPT_REQUEST, database, table, scriptType });
-    try {
-      const dbConn = getDBConnByName(database);
-      const [script] = await dbConn.getViewCreateScript(table);
-      dispatch({ type: GET_SCRIPT_SUCCESS, database, table, script, scriptType });
+      let script;
+      if (actionType === 'CREATE') {
+        [script] = objectType === 'Table'
+          ? await dbConn.getTableCreateScript(table)
+          : await dbConn.getViewCreateScript(table);
+      } else if (actionType === 'SELECT') {
+        script = await dbConn.getTableSelectScript(table);
+      } else if (actionType === 'INSERT') {
+        script = await dbConn.getTableInsertScript(table);
+      } else if (actionType === 'UPDATE') {
+        script = await dbConn.getTableUpdateScript(table);
+      } else if (actionType === 'DELETE') {
+        script = await dbConn.getTableDeleteScript(table);
+      }
+      dispatch({ type: GET_SCRIPT_SUCCESS, database, table, script, actionType, objectType });
       dispatch(updateQueryIfNeeded(script));
     } catch (error) {
       dispatch({ type: GET_SCRIPT_FAILURE, error });

--- a/src/renderer/actions/sqlscripts.js
+++ b/src/renderer/actions/sqlscripts.js
@@ -9,20 +9,36 @@ export const GET_SCRIPT_FAILURE = 'GET_SCRIPT_FAILURE';
 
 export function getSQLScriptIfNeeded(database, table, actionType, objectType) {
   return (dispatch, getState) => {
-    if (shouldFetchScript(getState(), database, table, actionType)) {
+    const state = getState();
+    if (shouldFetchScript(state, database, table, actionType)) {
       return dispatch(getSQLScript(database, table, actionType, objectType));
+    } else if (isScriptAlreadyFetched(state, database, table, actionType)) {
+      const script = getAlreadyFetchedScript(state, database, table, actionType);
+      return dispatch(updateQueryIfNeeded(script));
     }
   };
 }
 
-function shouldFetchScript (state, database, table, scriptType) {
+function shouldFetchScript (state, database, table, actionType) {
   const scripts = state.sqlscripts;
   if (!scripts) return true;
   if (scripts.isFetching) return false;
   if (!scripts.scriptsByObject[database]) return true;
   if (!scripts.scriptsByObject[database][table]) return true;
-  if (!scripts.scriptsByObject[database][table][scriptType]) return true;
+  if (!scripts.scriptsByObject[database][table][actionType]) return true;
   return scripts.didInvalidate;
+}
+
+function isScriptAlreadyFetched (state, database, table, actionType) {
+  const scripts = state.sqlscripts;
+  if (!scripts.scriptsByObject[database]) return false;
+  if (!scripts.scriptsByObject[database][table]) return false;
+  if (scripts.scriptsByObject[database][table][actionType]) return true;
+  return false;
+}
+
+function getAlreadyFetchedScript (state, database, table, actionType) {
+  return state.sqlscripts.scriptsByObject[database][table][actionType];
 }
 
 

--- a/src/renderer/components/database-item.jsx
+++ b/src/renderer/components/database-item.jsx
@@ -1,0 +1,93 @@
+import React, { Component, PropTypes } from 'react';
+import TableSubmenu from './table-submenu.jsx';
+
+
+const STYLE = {
+  item: { wordBreak: 'break-all', cursor: 'default' },
+};
+
+
+export default class DatabaseItem extends Component {
+  static propTypes = {
+    database: PropTypes.object.isRequired,
+    item: PropTypes.object.isRequired,
+    dbObjectType: PropTypes.string.isRequired,
+    title: PropTypes.string,
+    style: PropTypes.object,
+    columnsByTable: PropTypes.object,
+    triggersByTable: PropTypes.object,
+    onSelectItem: PropTypes.func,
+    onDoubleClick: PropTypes.func,
+  }
+
+  constructor(props, context) {
+    super(props, context);
+    this.state = {};
+    //this.contextMenu;
+  }
+
+  toggleTableCollapse() {
+    this.setState({ tableCollapsed: !this.state.tableCollapsed });
+  }
+
+  renderSubItems(table) {
+    const { columnsByTable, triggersByTable, database } = this.props;
+
+    if (!columnsByTable || !columnsByTable[table]) {
+      return null;
+    }
+
+    const displayStyle = {};
+    if (!this.state.tableCollapsed) {
+      displayStyle.display = 'none';
+    }
+
+    return (
+      <div style={displayStyle}>
+        <TableSubmenu
+          title="Columns"
+          table={table}
+          itemsByTable={columnsByTable}
+          database={database}/>
+        <TableSubmenu
+          collapsed
+          title="Triggers"
+          table={table}
+          itemsByTable={triggersByTable}
+          database={database}/>
+      </div>
+    );
+  }
+
+  render() {
+    const { database, item, title, style, onDoubleClick, onSelectItem, dbObjectType } = this.props;
+    const hasChildElements = !!onSelectItem;
+    const onSingleClick = hasChildElements
+      ? () => {onSelectItem(database, item); this.toggleTableCollapse();}
+      : () => {};
+
+    const collapseCssClass = this.state.tableCollapsed ? 'down' : 'right';
+    const collapseIcon = (
+      <i className={`${collapseCssClass} triangle icon`} style={{float: 'left', margin: '0 0.15em 0 -1em'}}></i>
+    );
+    const tableIcon = (
+      <i className="table icon" style={{float: 'left', margin: '0 0.3em 0 0'}}></i>
+    );
+
+    return (
+      <div>
+        <span
+          title={title}
+          style={style}
+          className="item"
+          onClick={onSingleClick}
+          onDoubleClick={onDoubleClick}>
+          { dbObjectType === 'Tables' ? collapseIcon : null }
+          { dbObjectType === 'Tables' ? tableIcon : null }
+          {item.name}
+        </span>
+        {this.renderSubItems(item.name)}
+      </div>
+    );
+  }
+}

--- a/src/renderer/components/database-item.jsx
+++ b/src/renderer/components/database-item.jsx
@@ -60,25 +60,26 @@ export default class DatabaseItem extends Component {
     const scriptsNames = ['CREATE', 'SELECT', 'INSERT', 'UPDATE', 'DELETE'];
 
     this.contextMenu = new Menu();
-    if (dbObjectType === 'Tables' || dbObjectType === 'Views') {
-      this.contextMenu.append(new MenuItem({
-        label: `Execute default query`,
-        click: onExecuteDefaultQuery.bind(this, database, item)
-      }));
-      if (dbObjectType === 'Tables') {
-        scriptFuncs.map((currentValue, index) => {
-          this.contextMenu.append(new MenuItem({
-            label: `${scriptsNames[index]} script`,
-            click: currentValue.bind(this, database, item)
-          }));
-        });
-      } else {
-        this.contextMenu.append(new MenuItem({
-          label: `CREATE script`,
-          click: onGetViewCreateScript.bind(this, database, item)
-        }));
-      }
+    if (dbObjectType !== 'Tables' && dbObjectType !== 'Views') {
+      return;
     }
+    this.contextMenu.append(new MenuItem({
+      label: `Execute default query`,
+      click: onExecuteDefaultQuery.bind(this, database, item)
+    }));
+    if (dbObjectType === 'Tables') {
+      scriptFuncs.map((currentValue, index) => {
+        this.contextMenu.append(new MenuItem({
+          label: `${scriptsNames[index]} script`,
+          click: currentValue.bind(this, database, item)
+        }));
+      });
+      return;
+    }
+    this.contextMenu.append(new MenuItem({
+      label: `CREATE script`,
+      click: onGetViewCreateScript.bind(this, database, item)
+    }));
   }
 
   toggleTableCollapse() {

--- a/src/renderer/components/database-item.jsx
+++ b/src/renderer/components/database-item.jsx
@@ -51,10 +51,10 @@ export default class DatabaseItem extends Component {
     const actionTypes = ['SELECT', 'INSERT', 'UPDATE', 'DELETE'];
 
     this.contextMenu = new Menu();
-    if (dbObjectType !== 'Tables' && dbObjectType !== 'Views') {
+    if (dbObjectType !== 'Table' && dbObjectType !== 'View') {
       this.contextMenu.append(new MenuItem({
         label: `${dbObjectType} SQL definition`,
-        click: onGetRoutineSQL.bind(this, database, item, dbObjectType.slice(0, -1))
+        click: onGetRoutineSQL.bind(this, database, item, dbObjectType)
       }));
       return;
     }
@@ -64,13 +64,13 @@ export default class DatabaseItem extends Component {
     }));
     this.contextMenu.append(new MenuItem({
       label: `CREATE script`,
-      click: onGetSQLScript.bind(this, database, item, 'CREATE', dbObjectType.slice(0, -1))
+      click: onGetSQLScript.bind(this, database, item, 'CREATE', dbObjectType)
     }));
-    if (dbObjectType === 'Tables') {
+    if (dbObjectType === 'Table') {
       actionTypes.map((actionType, index) => {
         this.contextMenu.append(new MenuItem({
           label: `${actionType} script`,
-          click: onGetSQLScript.bind(this, database, item, actionType, dbObjectType.slice(0, -1))
+          click: onGetSQLScript.bind(this, database, item, actionType, dbObjectType)
         }));
       });
     }
@@ -131,8 +131,8 @@ export default class DatabaseItem extends Component {
           className="item"
           onClick={onSingleClick}
           onContextMenu={::this.onContextMenu}>
-          { dbObjectType === 'Tables' ? collapseIcon : null }
-          { dbObjectType === 'Tables' ? tableIcon : null }
+          { dbObjectType === 'Table' ? collapseIcon : null }
+          { dbObjectType === 'Table' ? tableIcon : null }
           {item.name}
         </span>
         {this.renderSubItems(item.name)}

--- a/src/renderer/components/database-item.jsx
+++ b/src/renderer/components/database-item.jsx
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import TableSubmenu from './table-submenu.jsx';
+import { Menu, MenuItem } from 'remote';
 
 
 const STYLE = {
@@ -23,7 +24,29 @@ export default class DatabaseItem extends Component {
   constructor(props, context) {
     super(props, context);
     this.state = {};
-    //this.contextMenu;
+    this.contextMenu;
+  }
+
+  // Context menu is built dinamically on click (if it does not exist), because building
+  // menu onComponentDidMount or onComponentWillMount slows table listing when database
+  // has a loads of tables, because menu will be created (unnecessarily) for every table shown
+  onContextMenu(e){
+    e.preventDefault();
+    if (!this.contextMenu){
+      this.buildContextMenu();
+    }
+    this.contextMenu.popup(e.clientX, e.clientY);
+  }
+
+  buildContextMenu(){
+    const { dbObjectType, onDoubleClick } = this.props;
+    this.contextMenu = new Menu();
+    if (dbObjectType === 'Tables' || dbObjectType === 'Views') {
+      this.contextMenu.append(new MenuItem({
+        label: `Execute default query ${dbObjectType}`,
+        click: onDoubleClick
+      }));
+    }
   }
 
   toggleTableCollapse() {
@@ -60,7 +83,7 @@ export default class DatabaseItem extends Component {
   }
 
   render() {
-    const { database, item, title, style, onDoubleClick, onSelectItem, dbObjectType } = this.props;
+    const { database, item, title, style, onSelectItem, dbObjectType } = this.props;
     const hasChildElements = !!onSelectItem;
     const onSingleClick = hasChildElements
       ? () => {onSelectItem(database, item); this.toggleTableCollapse();}
@@ -81,7 +104,7 @@ export default class DatabaseItem extends Component {
           style={style}
           className="item"
           onClick={onSingleClick}
-          onDoubleClick={onDoubleClick}>
+          onContextMenu={::this.onContextMenu}>
           { dbObjectType === 'Tables' ? collapseIcon : null }
           { dbObjectType === 'Tables' ? tableIcon : null }
           {item.name}

--- a/src/renderer/components/database-item.jsx
+++ b/src/renderer/components/database-item.jsx
@@ -19,6 +19,12 @@ export default class DatabaseItem extends Component {
     triggersByTable: PropTypes.object,
     onSelectItem: PropTypes.func,
     onDoubleClick: PropTypes.func,
+    onGetTableCreateScript: PropTypes.func,
+    onGetTableSelectScript: PropTypes.func,
+    onGetTableInsertScript: PropTypes.func,
+    onGetTableUpdateScript: PropTypes.func,
+    onGetTableDeleteScript: PropTypes.func,
+    onGetViewCreateScript: PropTypes.func,
   }
 
   constructor(props, context) {
@@ -39,13 +45,40 @@ export default class DatabaseItem extends Component {
   }
 
   buildContextMenu(){
-    const { dbObjectType, onDoubleClick } = this.props;
+    const {
+      database,
+      item,
+      dbObjectType,
+      onDoubleClick,
+      onGetTableCreateScript,
+      onGetTableSelectScript,
+      onGetTableInsertScript,
+      onGetTableUpdateScript,
+      onGetTableDeleteScript,
+      onGetViewCreateScript,
+    } = this.props;
+    const scriptFuncs = [onGetTableCreateScript, onGetTableSelectScript, onGetTableInsertScript, onGetTableUpdateScript, onGetTableDeleteScript];
+    const scriptsNames = ['CREATE', 'SELECT', 'INSERT', 'UPDATE', 'DELETE'];
+
     this.contextMenu = new Menu();
     if (dbObjectType === 'Tables' || dbObjectType === 'Views') {
       this.contextMenu.append(new MenuItem({
-        label: `Execute default query ${dbObjectType}`,
+        label: `Execute default query`,
         click: onDoubleClick
       }));
+      if (dbObjectType === 'Tables') {
+        scriptFuncs.map((currentValue, index) => {
+          this.contextMenu.append(new MenuItem({
+            label: `${scriptsNames[index]} script`,
+            click: currentValue.bind(this, database, item)
+          }));
+        });
+      } else {
+        this.contextMenu.append(new MenuItem({
+          label: `CREATE script`,
+          click: onGetViewCreateScript.bind(this, database, item)
+        }));
+      }
     }
   }
 

--- a/src/renderer/components/database-item.jsx
+++ b/src/renderer/components/database-item.jsx
@@ -13,12 +13,11 @@ export default class DatabaseItem extends Component {
     database: PropTypes.object.isRequired,
     item: PropTypes.object.isRequired,
     dbObjectType: PropTypes.string.isRequired,
-    title: PropTypes.string,
     style: PropTypes.object,
     columnsByTable: PropTypes.object,
     triggersByTable: PropTypes.object,
     onSelectItem: PropTypes.func,
-    onDoubleClick: PropTypes.func,
+    onExecuteDefaultQuery: PropTypes.func,
     onGetTableCreateScript: PropTypes.func,
     onGetTableSelectScript: PropTypes.func,
     onGetTableInsertScript: PropTypes.func,
@@ -49,7 +48,7 @@ export default class DatabaseItem extends Component {
       database,
       item,
       dbObjectType,
-      onDoubleClick,
+      onExecuteDefaultQuery,
       onGetTableCreateScript,
       onGetTableSelectScript,
       onGetTableInsertScript,
@@ -64,7 +63,7 @@ export default class DatabaseItem extends Component {
     if (dbObjectType === 'Tables' || dbObjectType === 'Views') {
       this.contextMenu.append(new MenuItem({
         label: `Execute default query`,
-        click: onDoubleClick
+        click: onExecuteDefaultQuery.bind(this, database, item)
       }));
       if (dbObjectType === 'Tables') {
         scriptFuncs.map((currentValue, index) => {
@@ -116,7 +115,7 @@ export default class DatabaseItem extends Component {
   }
 
   render() {
-    const { database, item, title, style, onSelectItem, dbObjectType } = this.props;
+    const { database, item, style, onSelectItem, dbObjectType } = this.props;
     const hasChildElements = !!onSelectItem;
     const onSingleClick = hasChildElements
       ? () => {onSelectItem(database, item); this.toggleTableCollapse();}
@@ -133,7 +132,6 @@ export default class DatabaseItem extends Component {
     return (
       <div>
         <span
-          title={title}
           style={style}
           className="item"
           onClick={onSingleClick}

--- a/src/renderer/components/database-item.jsx
+++ b/src/renderer/components/database-item.jsx
@@ -19,7 +19,6 @@ export default class DatabaseItem extends Component {
     onSelectItem: PropTypes.func,
     onExecuteDefaultQuery: PropTypes.func,
     onGetSQLScript: PropTypes.func,
-    onGetRoutineSQL: PropTypes.func,
   }
 
   constructor(props, context) {
@@ -46,24 +45,18 @@ export default class DatabaseItem extends Component {
       dbObjectType,
       onExecuteDefaultQuery,
       onGetSQLScript,
-      onGetRoutineSQL,
     } = this.props;
     const actionTypes = ['SELECT', 'INSERT', 'UPDATE', 'DELETE'];
 
     this.contextMenu = new Menu();
-    if (dbObjectType !== 'Table' && dbObjectType !== 'View') {
+    if (dbObjectType === 'Table' || dbObjectType === 'View') {
       this.contextMenu.append(new MenuItem({
-        label: `${dbObjectType} SQL definition`,
-        click: onGetRoutineSQL.bind(this, database, item, dbObjectType)
+        label: 'Execute default query',
+        click: onExecuteDefaultQuery.bind(this, database, item)
       }));
-      return;
     }
     this.contextMenu.append(new MenuItem({
-      label: `Execute default query`,
-      click: onExecuteDefaultQuery.bind(this, database, item)
-    }));
-    this.contextMenu.append(new MenuItem({
-      label: `CREATE script`,
+      label: 'CREATE script',
       click: onGetSQLScript.bind(this, database, item, 'CREATE', dbObjectType)
     }));
     if (dbObjectType === 'Table') {

--- a/src/renderer/components/database-item.jsx
+++ b/src/renderer/components/database-item.jsx
@@ -18,12 +18,7 @@ export default class DatabaseItem extends Component {
     triggersByTable: PropTypes.object,
     onSelectItem: PropTypes.func,
     onExecuteDefaultQuery: PropTypes.func,
-    onGetTableCreateScript: PropTypes.func,
-    onGetTableSelectScript: PropTypes.func,
-    onGetTableInsertScript: PropTypes.func,
-    onGetTableUpdateScript: PropTypes.func,
-    onGetTableDeleteScript: PropTypes.func,
-    onGetViewCreateScript: PropTypes.func,
+    onGetSQLScript: PropTypes.func,
   }
 
   constructor(props, context) {
@@ -49,15 +44,9 @@ export default class DatabaseItem extends Component {
       item,
       dbObjectType,
       onExecuteDefaultQuery,
-      onGetTableCreateScript,
-      onGetTableSelectScript,
-      onGetTableInsertScript,
-      onGetTableUpdateScript,
-      onGetTableDeleteScript,
-      onGetViewCreateScript,
+      onGetSQLScript,
     } = this.props;
-    const scriptFuncs = [onGetTableCreateScript, onGetTableSelectScript, onGetTableInsertScript, onGetTableUpdateScript, onGetTableDeleteScript];
-    const scriptsNames = ['CREATE', 'SELECT', 'INSERT', 'UPDATE', 'DELETE'];
+    const actionTypes = ['SELECT', 'INSERT', 'UPDATE', 'DELETE'];
 
     this.contextMenu = new Menu();
     if (dbObjectType !== 'Tables' && dbObjectType !== 'Views') {
@@ -67,19 +56,18 @@ export default class DatabaseItem extends Component {
       label: `Execute default query`,
       click: onExecuteDefaultQuery.bind(this, database, item)
     }));
-    if (dbObjectType === 'Tables') {
-      scriptFuncs.map((currentValue, index) => {
-        this.contextMenu.append(new MenuItem({
-          label: `${scriptsNames[index]} script`,
-          click: currentValue.bind(this, database, item)
-        }));
-      });
-      return;
-    }
     this.contextMenu.append(new MenuItem({
       label: `CREATE script`,
-      click: onGetViewCreateScript.bind(this, database, item)
+      click: onGetSQLScript.bind(this, database, item, 'CREATE', dbObjectType.slice(0, -1))
     }));
+    if (dbObjectType === 'Tables') {
+      actionTypes.map((actionType, index) => {
+        this.contextMenu.append(new MenuItem({
+          label: `${actionType} script`,
+          click: onGetSQLScript.bind(this, database, item, actionType, dbObjectType.slice(0, -1))
+        }));
+      });
+    }
   }
 
   toggleTableCollapse() {

--- a/src/renderer/components/database-item.jsx
+++ b/src/renderer/components/database-item.jsx
@@ -19,6 +19,7 @@ export default class DatabaseItem extends Component {
     onSelectItem: PropTypes.func,
     onExecuteDefaultQuery: PropTypes.func,
     onGetSQLScript: PropTypes.func,
+    onGetRoutineSQL: PropTypes.func,
   }
 
   constructor(props, context) {
@@ -45,11 +46,16 @@ export default class DatabaseItem extends Component {
       dbObjectType,
       onExecuteDefaultQuery,
       onGetSQLScript,
+      onGetRoutineSQL,
     } = this.props;
     const actionTypes = ['SELECT', 'INSERT', 'UPDATE', 'DELETE'];
 
     this.contextMenu = new Menu();
     if (dbObjectType !== 'Tables' && dbObjectType !== 'Views') {
+      this.contextMenu.append(new MenuItem({
+        label: `${dbObjectType} SQL definition`,
+        click: onGetRoutineSQL.bind(this, database, item, dbObjectType.slice(0, -1))
+      }));
       return;
     }
     this.contextMenu.append(new MenuItem({

--- a/src/renderer/components/database-list-item-metadata.jsx
+++ b/src/renderer/components/database-list-item-metadata.jsx
@@ -20,7 +20,6 @@ export default class DbMetadataList extends Component {
     onExecuteDefaultQuery: PropTypes.func,
     onSelectItem: PropTypes.func,
     onGetSQLScript: PropTypes.func,
-    onGetRoutineSQL: PropTypes.func,
   }
 
   constructor(props, context) {
@@ -61,7 +60,6 @@ export default class DbMetadataList extends Component {
       items,
       database,
       onGetSQLScript,
-      onGetRoutineSQL,
     } = this.props;
 
     if (!items || this.state.collapsed) {
@@ -94,8 +92,7 @@ export default class DbMetadataList extends Component {
           triggersByTable={this.props.triggersByTable}
           onSelectItem={onSelectItem}
           onExecuteDefaultQuery={onExecuteDefaultQuery}
-          onGetSQLScript={onGetSQLScript}
-          onGetRoutineSQL={onGetRoutineSQL} />
+          onGetSQLScript={onGetSQLScript} />
       );
     });
   }

--- a/src/renderer/components/database-list-item-metadata.jsx
+++ b/src/renderer/components/database-list-item-metadata.jsx
@@ -19,12 +19,7 @@ export default class DbMetadataList extends Component {
     database: PropTypes.object.isRequired,
     onExecuteDefaultQuery: PropTypes.func,
     onSelectItem: PropTypes.func,
-    onGetTableCreateScript: PropTypes.func,
-    onGetTableSelectScript: PropTypes.func,
-    onGetTableInsertScript: PropTypes.func,
-    onGetTableUpdateScript: PropTypes.func,
-    onGetTableDeleteScript: PropTypes.func,
-    onGetViewCreateScript: PropTypes.func,
+    onGetSQLScript: PropTypes.func,
   }
 
   constructor(props, context) {
@@ -64,12 +59,7 @@ export default class DbMetadataList extends Component {
       onSelectItem,
       items,
       database,
-      onGetTableCreateScript,
-      onGetTableSelectScript,
-      onGetTableInsertScript,
-      onGetTableUpdateScript,
-      onGetTableDeleteScript,
-      onGetViewCreateScript,
+      onGetSQLScript,
     } = this.props;
 
     if (!items || this.state.collapsed) {
@@ -102,12 +92,7 @@ export default class DbMetadataList extends Component {
           triggersByTable={this.props.triggersByTable}
           onSelectItem={onSelectItem}
           onExecuteDefaultQuery={onExecuteDefaultQuery}
-          onGetTableCreateScript={onGetTableCreateScript}
-          onGetTableSelectScript={onGetTableSelectScript}
-          onGetTableInsertScript={onGetTableInsertScript}
-          onGetTableUpdateScript={onGetTableUpdateScript}
-          onGetTableDeleteScript={onGetTableDeleteScript}
-          onGetViewCreateScript={onGetViewCreateScript} />
+          onGetSQLScript={onGetSQLScript} />
       );
     });
   }

--- a/src/renderer/components/database-list-item-metadata.jsx
+++ b/src/renderer/components/database-list-item-metadata.jsx
@@ -19,6 +19,12 @@ export default class DbMetadataList extends Component {
     database: PropTypes.object.isRequired,
     onDoubleClickItem: PropTypes.func,
     onSelectItem: PropTypes.func,
+    onGetTableCreateScript: PropTypes.func,
+    onGetTableSelectScript: PropTypes.func,
+    onGetTableInsertScript: PropTypes.func,
+    onGetTableUpdateScript: PropTypes.func,
+    onGetTableDeleteScript: PropTypes.func,
+    onGetViewCreateScript: PropTypes.func,
   }
 
   constructor(props, context) {
@@ -53,7 +59,18 @@ export default class DbMetadataList extends Component {
   }
 
   renderItems() {
-    const { onDoubleClickItem, onSelectItem, items, database } = this.props;
+    const {
+      onDoubleClickItem,
+      onSelectItem,
+      items,
+      database,
+      onGetTableCreateScript,
+      onGetTableSelectScript,
+      onGetTableInsertScript,
+      onGetTableUpdateScript,
+      onGetTableDeleteScript,
+      onGetViewCreateScript,
+    } = this.props;
 
     if (!items || this.state.collapsed) {
       return null;
@@ -90,7 +107,13 @@ export default class DbMetadataList extends Component {
           columnsByTable={this.props.columnsByTable}
           triggersByTable={this.props.triggersByTable}
           onSelectItem={onSelectItem}
-          onDoubleClick={onDoubleClick}/>
+          onDoubleClick={onDoubleClick}
+          onGetTableCreateScript={onGetTableCreateScript}
+          onGetTableSelectScript={onGetTableSelectScript}
+          onGetTableInsertScript={onGetTableInsertScript}
+          onGetTableUpdateScript={onGetTableUpdateScript}
+          onGetTableDeleteScript={onGetTableDeleteScript}
+          onGetViewCreateScript={onGetViewCreateScript} />
       );
     });
   }

--- a/src/renderer/components/database-list-item-metadata.jsx
+++ b/src/renderer/components/database-list-item-metadata.jsx
@@ -20,6 +20,7 @@ export default class DbMetadataList extends Component {
     onExecuteDefaultQuery: PropTypes.func,
     onSelectItem: PropTypes.func,
     onGetSQLScript: PropTypes.func,
+    onGetRoutineSQL: PropTypes.func,
   }
 
   constructor(props, context) {
@@ -60,6 +61,7 @@ export default class DbMetadataList extends Component {
       items,
       database,
       onGetSQLScript,
+      onGetRoutineSQL,
     } = this.props;
 
     if (!items || this.state.collapsed) {
@@ -92,7 +94,8 @@ export default class DbMetadataList extends Component {
           triggersByTable={this.props.triggersByTable}
           onSelectItem={onSelectItem}
           onExecuteDefaultQuery={onExecuteDefaultQuery}
-          onGetSQLScript={onGetSQLScript} />
+          onGetSQLScript={onGetSQLScript}
+          onGetRoutineSQL={onGetRoutineSQL} />
       );
     });
   }

--- a/src/renderer/components/database-list-item-metadata.jsx
+++ b/src/renderer/components/database-list-item-metadata.jsx
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react';
-import TableSubmenu from './table-submenu.jsx';
+import DatabaseItem from './database-item.jsx';
+
 
 const STYLE = {
   header: { fontSize: '0.85em', color: '#636363' },
@@ -33,10 +34,6 @@ export default class DbMetadataList extends Component {
 
   toggleCollapse() {
     this.setState({ collapsed: !this.state.collapsed });
-  }
-
-  toggleTableCollapse(tableName) {
-    this.setState({ [tableName]: !this.state[tableName] });
   }
 
   renderHeader() {
@@ -75,71 +72,27 @@ export default class DbMetadataList extends Component {
       const onDoubleClick = isClickable
         ? onDoubleClickItem.bind(this, database, item)
         : () => {};
-      const onSingleClick = hasChildElements
-        ? () => {onSelectItem(database, item); this.toggleTableCollapse(item.name);}
-        : () => {};
 
       const cssStyle = {...STYLE.item};
       if (this.state.collapsed) {
         cssStyle.display = 'none';
       }
       cssStyle.cursor = hasChildElements ? 'pointer' : 'default';
-      const collapseCssClass = this.state[item.name] ? 'down' : 'right';
-      const collapseIcon = (
-        <i className={`${collapseCssClass} triangle icon`} style={{float: 'left', margin: '0 0.15em 0 -1em'}}></i>
-      );
-      const tableIcon = (
-        <i className="table icon" style={{float: 'left', margin: '0 0.3em 0 0'}}></i>
-      );
 
-      /*
-        TODO: Move standard table query to context menu
-       */
       return (
-        <div key={item.name}>
-          <span
-            title={title}
-            style={cssStyle}
-            className="item"
-            onDoubleClick={onDoubleClick}
-            onClick={onSingleClick}>
-            { this.props.title === 'Tables' ? collapseIcon : null }
-            { this.props.title === 'Tables' ? tableIcon : null }
-            {item.name}
-          </span>
-          {this.renderSubItems(item.name)}
-        </div>
+        <DatabaseItem
+          key={item.name}
+          database={database}
+          item={item}
+          dbObjectType = {this.props.title}
+          title={title}
+          style={cssStyle}
+          columnsByTable={this.props.columnsByTable}
+          triggersByTable={this.props.triggersByTable}
+          onSelectItem={onSelectItem}
+          onDoubleClick={onDoubleClick}/>
       );
     });
-  }
-
-  renderSubItems(table) {
-    const { columnsByTable, triggersByTable, database } = this.props;
-
-    if (!columnsByTable || !columnsByTable[table]) {
-      return null;
-    }
-
-    const displayStyle = {};
-    if (!this.state[table]) {
-      displayStyle.display = 'none';
-    }
-
-    return (
-      <div style={displayStyle}>
-        <TableSubmenu
-          title="Columns"
-          table={table}
-          itemsByTable={columnsByTable}
-          database={database}/>
-        <TableSubmenu
-          collapsed
-          title="Triggers"
-          table={table}
-          itemsByTable={triggersByTable}
-          database={database}/>
-      </div>
-    );
   }
 
   render() {

--- a/src/renderer/components/database-list-item-metadata.jsx
+++ b/src/renderer/components/database-list-item-metadata.jsx
@@ -17,7 +17,7 @@ export default class DbMetadataList extends Component {
     triggersByTable: PropTypes.object,
     collapsed: PropTypes.bool,
     database: PropTypes.object.isRequired,
-    onDoubleClickItem: PropTypes.func,
+    onExecuteDefaultQuery: PropTypes.func,
     onSelectItem: PropTypes.func,
     onGetTableCreateScript: PropTypes.func,
     onGetTableSelectScript: PropTypes.func,
@@ -60,7 +60,7 @@ export default class DbMetadataList extends Component {
 
   renderItems() {
     const {
-      onDoubleClickItem,
+      onExecuteDefaultQuery,
       onSelectItem,
       items,
       database,
@@ -83,12 +83,7 @@ export default class DbMetadataList extends Component {
     }
 
     return items.map(item => {
-      const isClickable = !!onDoubleClickItem;
       const hasChildElements = !!onSelectItem;
-      const title = isClickable ? 'Click twice to select default query' : '';
-      const onDoubleClick = isClickable
-        ? onDoubleClickItem.bind(this, database, item)
-        : () => {};
 
       const cssStyle = {...STYLE.item};
       if (this.state.collapsed) {
@@ -101,13 +96,12 @@ export default class DbMetadataList extends Component {
           key={item.name}
           database={database}
           item={item}
-          dbObjectType = {this.props.title}
-          title={title}
+          dbObjectType={this.props.title}
           style={cssStyle}
           columnsByTable={this.props.columnsByTable}
           triggersByTable={this.props.triggersByTable}
           onSelectItem={onSelectItem}
-          onDoubleClick={onDoubleClick}
+          onExecuteDefaultQuery={onExecuteDefaultQuery}
           onGetTableCreateScript={onGetTableCreateScript}
           onGetTableSelectScript={onGetTableSelectScript}
           onGetTableInsertScript={onGetTableInsertScript}

--- a/src/renderer/components/database-list-item-metadata.jsx
+++ b/src/renderer/components/database-list-item-metadata.jsx
@@ -88,7 +88,7 @@ export default class DbMetadataList extends Component {
           key={item.name}
           database={database}
           item={item}
-          dbObjectType={this.props.title}
+          dbObjectType={this.props.title.slice(0, -1)}
           style={cssStyle}
           columnsByTable={this.props.columnsByTable}
           triggersByTable={this.props.triggersByTable}

--- a/src/renderer/components/database-list-item.jsx
+++ b/src/renderer/components/database-list-item.jsx
@@ -23,12 +23,7 @@ export default class DatabaseListItem extends Component {
     onExecuteDefaultQuery: PropTypes.func.isRequired,
     onSelectTable: PropTypes.func.isRequired,
     onSelectDatabase: PropTypes.func.isRequired,
-    onGetTableCreateScript: PropTypes.func.isRequired,
-    onGetTableSelectScript: PropTypes.func.isRequired,
-    onGetTableInsertScript: PropTypes.func.isRequired,
-    onGetTableUpdateScript: PropTypes.func.isRequired,
-    onGetTableDeleteScript: PropTypes.func.isRequired,
-    onGetViewCreateScript: PropTypes.func.isRequired,
+    onGetSQLScript: PropTypes.func.isRequired,
   }
 
   constructor(props, context) {
@@ -82,12 +77,7 @@ export default class DatabaseListItem extends Component {
       onExecuteDefaultQuery,
       onSelectTable,
       onSelectDatabase,
-      onGetTableCreateScript,
-      onGetTableSelectScript,
-      onGetTableInsertScript,
-      onGetTableUpdateScript,
-      onGetTableDeleteScript,
-      onGetViewCreateScript,
+      onGetSQLScript,
     } = this.props;
     let filteredTables, filteredViews, filteredFunctions, filteredProcedures;
 
@@ -126,18 +116,14 @@ export default class DatabaseListItem extends Component {
             database={database}
             onExecuteDefaultQuery={onExecuteDefaultQuery}
             onSelectItem={onSelectTable}
-            onGetTableCreateScript={onGetTableCreateScript}
-            onGetTableSelectScript={onGetTableSelectScript}
-            onGetTableInsertScript={onGetTableInsertScript}
-            onGetTableUpdateScript={onGetTableUpdateScript}
-            onGetTableDeleteScript={onGetTableDeleteScript} />
+            onGetSQLScript={onGetSQLScript} />
           <DatabaseListItemMetatada
             collapsed
             title="Views"
             items={filteredViews || views}
             database={database}
             onExecuteDefaultQuery={onExecuteDefaultQuery}
-            onGetViewCreateScript={onGetViewCreateScript} />
+            onGetSQLScript={onGetSQLScript} />
           <DatabaseListItemMetatada
             collapsed
             title="Functions"

--- a/src/renderer/components/database-list-item.jsx
+++ b/src/renderer/components/database-list-item.jsx
@@ -20,7 +20,7 @@ export default class DatabaseListItem extends Component {
     functions: PropTypes.array,
     procedures: PropTypes.array,
     database: PropTypes.object.isRequired,
-    onDoubleClickTable: PropTypes.func.isRequired,
+    onExecuteDefaultQuery: PropTypes.func.isRequired,
     onSelectTable: PropTypes.func.isRequired,
     onSelectDatabase: PropTypes.func.isRequired,
     onGetTableCreateScript: PropTypes.func.isRequired,
@@ -79,7 +79,7 @@ export default class DatabaseListItem extends Component {
       functions,
       procedures,
       database,
-      onDoubleClickTable,
+      onExecuteDefaultQuery,
       onSelectTable,
       onSelectDatabase,
       onGetTableCreateScript,
@@ -124,7 +124,7 @@ export default class DatabaseListItem extends Component {
             columnsByTable={columnsByTable}
             triggersByTable={triggersByTable}
             database={database}
-            onDoubleClickItem={onDoubleClickTable}
+            onExecuteDefaultQuery={onExecuteDefaultQuery}
             onSelectItem={onSelectTable}
             onGetTableCreateScript={onGetTableCreateScript}
             onGetTableSelectScript={onGetTableSelectScript}
@@ -136,7 +136,7 @@ export default class DatabaseListItem extends Component {
             title="Views"
             items={filteredViews || views}
             database={database}
-            onDoubleClickItem={onDoubleClickTable}
+            onExecuteDefaultQuery={onExecuteDefaultQuery}
             onGetViewCreateScript={onGetViewCreateScript} />
           <DatabaseListItemMetatada
             collapsed

--- a/src/renderer/components/database-list-item.jsx
+++ b/src/renderer/components/database-list-item.jsx
@@ -23,6 +23,12 @@ export default class DatabaseListItem extends Component {
     onDoubleClickTable: PropTypes.func.isRequired,
     onSelectTable: PropTypes.func.isRequired,
     onSelectDatabase: PropTypes.func.isRequired,
+    onGetTableCreateScript: PropTypes.func.isRequired,
+    onGetTableSelectScript: PropTypes.func.isRequired,
+    onGetTableInsertScript: PropTypes.func.isRequired,
+    onGetTableUpdateScript: PropTypes.func.isRequired,
+    onGetTableDeleteScript: PropTypes.func.isRequired,
+    onGetViewCreateScript: PropTypes.func.isRequired,
   }
 
   constructor(props, context) {
@@ -75,7 +81,13 @@ export default class DatabaseListItem extends Component {
       database,
       onDoubleClickTable,
       onSelectTable,
-      onSelectDatabase
+      onSelectDatabase,
+      onGetTableCreateScript,
+      onGetTableSelectScript,
+      onGetTableInsertScript,
+      onGetTableUpdateScript,
+      onGetTableDeleteScript,
+      onGetViewCreateScript,
     } = this.props;
     let filteredTables, filteredViews, filteredFunctions, filteredProcedures;
 
@@ -113,13 +125,19 @@ export default class DatabaseListItem extends Component {
             triggersByTable={triggersByTable}
             database={database}
             onDoubleClickItem={onDoubleClickTable}
-            onSelectItem={onSelectTable} />
+            onSelectItem={onSelectTable}
+            onGetTableCreateScript={onGetTableCreateScript}
+            onGetTableSelectScript={onGetTableSelectScript}
+            onGetTableInsertScript={onGetTableInsertScript}
+            onGetTableUpdateScript={onGetTableUpdateScript}
+            onGetTableDeleteScript={onGetTableDeleteScript} />
           <DatabaseListItemMetatada
             collapsed
             title="Views"
             items={filteredViews || views}
             database={database}
-            onDoubleClickItem={onDoubleClickTable} />
+            onDoubleClickItem={onDoubleClickTable}
+            onGetViewCreateScript={onGetViewCreateScript} />
           <DatabaseListItemMetatada
             collapsed
             title="Functions"

--- a/src/renderer/components/database-list-item.jsx
+++ b/src/renderer/components/database-list-item.jsx
@@ -24,7 +24,6 @@ export default class DatabaseListItem extends Component {
     onSelectTable: PropTypes.func.isRequired,
     onSelectDatabase: PropTypes.func.isRequired,
     onGetSQLScript: PropTypes.func.isRequired,
-    onGetRoutineSQL: PropTypes.func.isRequired,
   }
 
   constructor(props, context) {
@@ -79,7 +78,6 @@ export default class DatabaseListItem extends Component {
       onSelectTable,
       onSelectDatabase,
       onGetSQLScript,
-      onGetRoutineSQL,
     } = this.props;
     let filteredTables, filteredViews, filteredFunctions, filteredProcedures;
 
@@ -131,13 +129,13 @@ export default class DatabaseListItem extends Component {
             title="Functions"
             items={filteredFunctions || functions}
             database={database}
-            onGetRoutineSQL={onGetRoutineSQL} />
+            onGetSQLScript={onGetSQLScript} />
           <DatabaseListItemMetatada
             collapsed
             title="Procedures"
             items={filteredProcedures || procedures}
             database={database}
-            onGetRoutineSQL={onGetRoutineSQL} />
+            onGetSQLScript={onGetSQLScript} />
         </div>
       </div>
     );

--- a/src/renderer/components/database-list-item.jsx
+++ b/src/renderer/components/database-list-item.jsx
@@ -24,6 +24,7 @@ export default class DatabaseListItem extends Component {
     onSelectTable: PropTypes.func.isRequired,
     onSelectDatabase: PropTypes.func.isRequired,
     onGetSQLScript: PropTypes.func.isRequired,
+    onGetRoutineSQL: PropTypes.func.isRequired,
   }
 
   constructor(props, context) {
@@ -78,6 +79,7 @@ export default class DatabaseListItem extends Component {
       onSelectTable,
       onSelectDatabase,
       onGetSQLScript,
+      onGetRoutineSQL,
     } = this.props;
     let filteredTables, filteredViews, filteredFunctions, filteredProcedures;
 
@@ -128,12 +130,14 @@ export default class DatabaseListItem extends Component {
             collapsed
             title="Functions"
             items={filteredFunctions || functions}
-            database={database} />
+            database={database}
+            onGetRoutineSQL={onGetRoutineSQL} />
           <DatabaseListItemMetatada
             collapsed
             title="Procedures"
             items={filteredProcedures || procedures}
-            database={database} />
+            database={database}
+            onGetRoutineSQL={onGetRoutineSQL} />
         </div>
       </div>
     );

--- a/src/renderer/components/database-list.jsx
+++ b/src/renderer/components/database-list.jsx
@@ -16,7 +16,6 @@ export default class DatabaseList extends Component {
     onExecuteDefaultQuery: PropTypes.func.isRequired,
     onSelectTable: PropTypes.func.isRequired,
     onGetSQLScript: PropTypes.func.isRequired,
-    onGetRoutineSQL: PropTypes.func.isRequired,
   }
 
   constructor(props, context) {
@@ -38,7 +37,6 @@ export default class DatabaseList extends Component {
       onSelectTable,
       onSelectDatabase,
       onGetSQLScript,
-      onGetRoutineSQL,
     } = this.props;
 
     if (isFetching) {
@@ -69,8 +67,7 @@ export default class DatabaseList extends Component {
             onExecuteDefaultQuery={onExecuteDefaultQuery}
             onSelectTable={onSelectTable}
             onSelectDatabase={onSelectDatabase}
-            onGetSQLScript={onGetSQLScript}
-            onGetRoutineSQL={onGetRoutineSQL} />
+            onGetSQLScript={onGetSQLScript} />
         ))
       }
       </div>

--- a/src/renderer/components/database-list.jsx
+++ b/src/renderer/components/database-list.jsx
@@ -16,6 +16,7 @@ export default class DatabaseList extends Component {
     onExecuteDefaultQuery: PropTypes.func.isRequired,
     onSelectTable: PropTypes.func.isRequired,
     onGetSQLScript: PropTypes.func.isRequired,
+    onGetRoutineSQL: PropTypes.func.isRequired,
   }
 
   constructor(props, context) {
@@ -37,6 +38,7 @@ export default class DatabaseList extends Component {
       onSelectTable,
       onSelectDatabase,
       onGetSQLScript,
+      onGetRoutineSQL,
     } = this.props;
 
     if (isFetching) {
@@ -67,7 +69,8 @@ export default class DatabaseList extends Component {
             onExecuteDefaultQuery={onExecuteDefaultQuery}
             onSelectTable={onSelectTable}
             onSelectDatabase={onSelectDatabase}
-            onGetSQLScript={onGetSQLScript} />
+            onGetSQLScript={onGetSQLScript}
+            onGetRoutineSQL={onGetRoutineSQL} />
         ))
       }
       </div>

--- a/src/renderer/components/database-list.jsx
+++ b/src/renderer/components/database-list.jsx
@@ -15,12 +15,7 @@ export default class DatabaseList extends Component {
     onSelectDatabase: PropTypes.func.isRequired,
     onExecuteDefaultQuery: PropTypes.func.isRequired,
     onSelectTable: PropTypes.func.isRequired,
-    onGetTableCreateScript: PropTypes.func.isRequired,
-    onGetTableSelectScript: PropTypes.func.isRequired,
-    onGetTableInsertScript: PropTypes.func.isRequired,
-    onGetTableUpdateScript: PropTypes.func.isRequired,
-    onGetTableDeleteScript: PropTypes.func.isRequired,
-    onGetViewCreateScript: PropTypes.func.isRequired,
+    onGetSQLScript: PropTypes.func.isRequired,
   }
 
   constructor(props, context) {
@@ -41,12 +36,7 @@ export default class DatabaseList extends Component {
       onExecuteDefaultQuery,
       onSelectTable,
       onSelectDatabase,
-      onGetTableCreateScript,
-      onGetTableSelectScript,
-      onGetTableInsertScript,
-      onGetTableUpdateScript,
-      onGetTableDeleteScript,
-      onGetViewCreateScript,
+      onGetSQLScript,
     } = this.props;
 
     if (isFetching) {
@@ -77,12 +67,7 @@ export default class DatabaseList extends Component {
             onExecuteDefaultQuery={onExecuteDefaultQuery}
             onSelectTable={onSelectTable}
             onSelectDatabase={onSelectDatabase}
-            onGetTableCreateScript={onGetTableCreateScript}
-            onGetTableSelectScript={onGetTableSelectScript}
-            onGetTableInsertScript={onGetTableInsertScript}
-            onGetTableUpdateScript={onGetTableUpdateScript}
-            onGetTableDeleteScript={onGetTableDeleteScript}
-            onGetViewCreateScript={onGetViewCreateScript} />
+            onGetSQLScript={onGetSQLScript} />
         ))
       }
       </div>

--- a/src/renderer/components/database-list.jsx
+++ b/src/renderer/components/database-list.jsx
@@ -13,7 +13,7 @@ export default class DatabaseList extends Component {
     functionsByDatabase: PropTypes.object.isRequired,
     proceduresByDatabase: PropTypes.object.isRequired,
     onSelectDatabase: PropTypes.func.isRequired,
-    onDoubleClickTable: PropTypes.func.isRequired,
+    onExecuteDefaultQuery: PropTypes.func.isRequired,
     onSelectTable: PropTypes.func.isRequired,
     onGetTableCreateScript: PropTypes.func.isRequired,
     onGetTableSelectScript: PropTypes.func.isRequired,
@@ -38,7 +38,7 @@ export default class DatabaseList extends Component {
       viewsByDatabase,
       functionsByDatabase,
       proceduresByDatabase,
-      onDoubleClickTable,
+      onExecuteDefaultQuery,
       onSelectTable,
       onSelectDatabase,
       onGetTableCreateScript,
@@ -74,7 +74,7 @@ export default class DatabaseList extends Component {
             views={viewsByDatabase[database.name]}
             functions={functionsByDatabase[database.name]}
             procedures={proceduresByDatabase[database.name]}
-            onDoubleClickTable={onDoubleClickTable}
+            onExecuteDefaultQuery={onExecuteDefaultQuery}
             onSelectTable={onSelectTable}
             onSelectDatabase={onSelectDatabase}
             onGetTableCreateScript={onGetTableCreateScript}

--- a/src/renderer/components/database-list.jsx
+++ b/src/renderer/components/database-list.jsx
@@ -15,6 +15,12 @@ export default class DatabaseList extends Component {
     onSelectDatabase: PropTypes.func.isRequired,
     onDoubleClickTable: PropTypes.func.isRequired,
     onSelectTable: PropTypes.func.isRequired,
+    onGetTableCreateScript: PropTypes.func.isRequired,
+    onGetTableSelectScript: PropTypes.func.isRequired,
+    onGetTableInsertScript: PropTypes.func.isRequired,
+    onGetTableUpdateScript: PropTypes.func.isRequired,
+    onGetTableDeleteScript: PropTypes.func.isRequired,
+    onGetViewCreateScript: PropTypes.func.isRequired,
   }
 
   constructor(props, context) {
@@ -35,6 +41,12 @@ export default class DatabaseList extends Component {
       onDoubleClickTable,
       onSelectTable,
       onSelectDatabase,
+      onGetTableCreateScript,
+      onGetTableSelectScript,
+      onGetTableInsertScript,
+      onGetTableUpdateScript,
+      onGetTableDeleteScript,
+      onGetViewCreateScript,
     } = this.props;
 
     if (isFetching) {
@@ -64,7 +76,13 @@ export default class DatabaseList extends Component {
             procedures={proceduresByDatabase[database.name]}
             onDoubleClickTable={onDoubleClickTable}
             onSelectTable={onSelectTable}
-            onSelectDatabase={onSelectDatabase} />
+            onSelectDatabase={onSelectDatabase}
+            onGetTableCreateScript={onGetTableCreateScript}
+            onGetTableSelectScript={onGetTableSelectScript}
+            onGetTableInsertScript={onGetTableInsertScript}
+            onGetTableUpdateScript={onGetTableUpdateScript}
+            onGetTableDeleteScript={onGetTableDeleteScript}
+            onGetViewCreateScript={onGetViewCreateScript} />
         ))
       }
       </div>

--- a/src/renderer/containers/query-browser.jsx
+++ b/src/renderer/containers/query-browser.jsx
@@ -11,7 +11,7 @@ import { fetchTableColumnsIfNeeded } from '../actions/columns';
 import { fetchTableTriggersIfNeeded } from '../actions/triggers';
 import { fetchViewsIfNeeded } from '../actions/views';
 import { fetchRoutinesIfNeeded } from '../actions/routines';
-import * as ScriptsActions from '../actions/sqlscripts';
+import { getSQLScriptIfNeeded } from '../actions/sqlscripts';
 import DatabaseFilter from '../components/database-filter.jsx';
 import DatabaseList from '../components/database-list.jsx';
 import Header from '../components/header.jsx';
@@ -121,28 +121,8 @@ class QueryBrowserContainer extends Component {
     this.props.dispatch(fetchTableTriggersIfNeeded(database.name, table.name));
   }
 
-  onGetTableCreateScript(database, table) {
-    this.props.dispatch(ScriptsActions.getTableCreateScriptIfNeeded(database.name, table.name));
-  }
-
-  onGetTableSelectScript(database, table) {
-    this.props.dispatch(ScriptsActions.getTableSelectScriptIfNeeded(database.name, table.name));
-  }
-
-  onGetTableInsertScript(database, table) {
-    this.props.dispatch(ScriptsActions.getTableInsertScriptIfNeeded(database.name, table.name));
-  }
-
-  onGetTableUpdateScript(database, table) {
-    this.props.dispatch(ScriptsActions.getTableUpdateScriptIfNeeded(database.name, table.name));
-  }
-
-  onGetTableDeleteScript(database, table) {
-    this.props.dispatch(ScriptsActions.getTableDeleteScriptIfNeeded(database.name, table.name));
-  }
-
-  onGetViewCreateScript(database, view) {
-    this.props.dispatch(ScriptsActions.getViewCreateScriptIfNeeded(database.name, view.name));
+  onGetSQLScript(database, table, actionType, objectType) {
+    this.props.dispatch(getSQLScriptIfNeeded(database.name, table.name, actionType, objectType));
   }
 
   onSQLChange (sqlQuery) {
@@ -336,12 +316,7 @@ class QueryBrowserContainer extends Component {
                   onSelectDatabase={::this.onSelectDatabase}
                   onExecuteDefaultQuery={::this.onExecuteDefaultQuery}
                   onSelectTable={::this.onSelectTable}
-                  onGetTableCreateScript={::this.onGetTableCreateScript}
-                  onGetTableSelectScript={::this.onGetTableSelectScript}
-                  onGetTableInsertScript={::this.onGetTableInsertScript}
-                  onGetTableUpdateScript={::this.onGetTableUpdateScript}
-                  onGetTableDeleteScript={::this.onGetTableDeleteScript}
-                  onGetViewCreateScript={::this.onGetViewCreateScript} />
+                  onGetSQLScript={::this.onGetSQLScript} />
               </div>
             </ResizableBox>
           </div>

--- a/src/renderer/containers/query-browser.jsx
+++ b/src/renderer/containers/query-browser.jsx
@@ -11,6 +11,7 @@ import { fetchTableColumnsIfNeeded } from '../actions/columns';
 import { fetchTableTriggersIfNeeded } from '../actions/triggers';
 import { fetchViewsIfNeeded } from '../actions/views';
 import { fetchRoutinesIfNeeded } from '../actions/routines';
+import * as ScriptsActions from '../actions/sqlscripts';
 import DatabaseFilter from '../components/database-filter.jsx';
 import DatabaseList from '../components/database-list.jsx';
 import Header from '../components/header.jsx';
@@ -51,6 +52,7 @@ class QueryBrowserContainer extends Component {
     views: PropTypes.object.isRequired,
     routines: PropTypes.object.isRequired,
     queries: PropTypes.object.isRequired,
+    sqlscripts: PropTypes.object.isRequired,
     dispatch: PropTypes.func.isRequired,
     history: PropTypes.object.isRequired,
     route: PropTypes.object.isRequired,
@@ -117,6 +119,31 @@ class QueryBrowserContainer extends Component {
   onSelectTable(database, table) {
     this.props.dispatch(fetchTableColumnsIfNeeded(database.name, table.name));
     this.props.dispatch(fetchTableTriggersIfNeeded(database.name, table.name));
+  }
+
+  onGetTableCreateScript(database, table) {
+    console.log('baza: ' + database.name + ' ,tablica: ' + table.name);
+    this.props.dispatch(ScriptsActions.getTableCreateScriptIfNeeded(database.name, table.name));
+  }
+
+  onGetTableSelectScript(database, table) {
+    this.props.dispatch(ScriptsActions.getTableSelectScriptIfNeeded(database.name, table.name));
+  }
+
+  onGetTableInsertScript(database, table) {
+    this.props.dispatch(ScriptsActions.getTableInsertScriptIfNeeded(database.name, table.name));
+  }
+
+  onGetTableUpdateScript(database, table) {
+    this.props.dispatch(ScriptsActions.getTableUpdateScriptIfNeeded(database.name, table.name));
+  }
+
+  onGetTableDeleteScript(database, table) {
+    this.props.dispatch(ScriptsActions.getTableDeleteScriptIfNeeded(database.name, table.name));
+  }
+
+  onGetViewCreateScript(database, view) {
+    this.props.dispatch(ScriptsActions.getViewCreateScriptIfNeeded(database.name, view.name));
   }
 
   onSQLChange (sqlQuery) {
@@ -309,7 +336,13 @@ class QueryBrowserContainer extends Component {
                   proceduresByDatabase={routines.proceduresByDatabase}
                   onSelectDatabase={::this.onSelectDatabase}
                   onDoubleClickTable={::this.onDoubleClickTable}
-                  onSelectTable={::this.onSelectTable} />
+                  onSelectTable={::this.onSelectTable}
+                  onGetTableCreateScript={::this.onGetTableCreateScript}
+                  onGetTableSelectScript={::this.onGetTableSelectScript}
+                  onGetTableInsertScript={::this.onGetTableInsertScript}
+                  onGetTableUpdateScript={::this.onGetTableUpdateScript}
+                  onGetTableDeleteScript={::this.onGetTableDeleteScript}
+                  onGetViewCreateScript={::this.onGetViewCreateScript} />
               </div>
             </ResizableBox>
           </div>
@@ -327,7 +360,7 @@ class QueryBrowserContainer extends Component {
 
 
 function mapStateToProps (state) {
-  const { connections, databases, tables, columns, triggers, views, routines, queries, status } = state;
+  const { connections, databases, tables, columns, triggers, views, routines, queries, sqlscripts, status } = state;
 
   return {
     connections,
@@ -338,6 +371,7 @@ function mapStateToProps (state) {
     views,
     routines,
     queries,
+    sqlscripts,
     status,
   };
 }

--- a/src/renderer/containers/query-browser.jsx
+++ b/src/renderer/containers/query-browser.jsx
@@ -122,7 +122,6 @@ class QueryBrowserContainer extends Component {
   }
 
   onGetTableCreateScript(database, table) {
-    console.log('baza: ' + database.name + ' ,tablica: ' + table.name);
     this.props.dispatch(ScriptsActions.getTableCreateScriptIfNeeded(database.name, table.name));
   }
 

--- a/src/renderer/containers/query-browser.jsx
+++ b/src/renderer/containers/query-browser.jsx
@@ -121,15 +121,8 @@ class QueryBrowserContainer extends Component {
     this.props.dispatch(fetchTableTriggersIfNeeded(database.name, table.name));
   }
 
-  onGetSQLScript(database, table, actionType, objectType) {
-    this.props.dispatch(getSQLScriptIfNeeded(database.name, table.name, actionType, objectType));
-  }
-
-  onGetRoutineSQL(database, item, objectType) {
-    const [routine] = objectType === 'Function'
-      ? this.props.routines.functionsByDatabase[database.name].filter(func => func.name === item.name)
-      : this.props.routines.proceduresByDatabase[database.name].filter(proc => proc.name === item.name);
-    this.props.dispatch(QueryActions.updateQueryIfNeeded(routine.routineDefinition));
+  onGetSQLScript(database, item, actionType, objectType) {
+    this.props.dispatch(getSQLScriptIfNeeded(database.name, item.name, actionType, objectType));
   }
 
   onSQLChange (sqlQuery) {
@@ -323,8 +316,7 @@ class QueryBrowserContainer extends Component {
                   onSelectDatabase={::this.onSelectDatabase}
                   onExecuteDefaultQuery={::this.onExecuteDefaultQuery}
                   onSelectTable={::this.onSelectTable}
-                  onGetSQLScript={::this.onGetSQLScript}
-                  onGetRoutineSQL={::this.onGetRoutineSQL} />
+                  onGetSQLScript={::this.onGetSQLScript} />
               </div>
             </ResizableBox>
           </div>

--- a/src/renderer/containers/query-browser.jsx
+++ b/src/renderer/containers/query-browser.jsx
@@ -125,6 +125,13 @@ class QueryBrowserContainer extends Component {
     this.props.dispatch(getSQLScriptIfNeeded(database.name, table.name, actionType, objectType));
   }
 
+  onGetRoutineSQL(database, item, objectType) {
+    const [routine] = objectType === 'Function'
+      ? this.props.routines.functionsByDatabase[database.name].filter(func => func.name === item.name)
+      : this.props.routines.proceduresByDatabase[database.name].filter(proc => proc.name === item.name);
+    this.props.dispatch(QueryActions.updateQueryIfNeeded(routine.routineDefinition));
+  }
+
   onSQLChange (sqlQuery) {
     this.props.dispatch(QueryActions.updateQueryIfNeeded(sqlQuery));
   }
@@ -316,7 +323,8 @@ class QueryBrowserContainer extends Component {
                   onSelectDatabase={::this.onSelectDatabase}
                   onExecuteDefaultQuery={::this.onExecuteDefaultQuery}
                   onSelectTable={::this.onSelectTable}
-                  onGetSQLScript={::this.onGetSQLScript} />
+                  onGetSQLScript={::this.onGetSQLScript}
+                  onGetRoutineSQL={::this.onGetRoutineSQL} />
               </div>
             </ResizableBox>
           </div>

--- a/src/renderer/containers/query-browser.jsx
+++ b/src/renderer/containers/query-browser.jsx
@@ -112,7 +112,7 @@ class QueryBrowserContainer extends Component {
     dispatch(ConnActions.connect(params.id, database.name));
   }
 
-  onDoubleClickTable(database, table) {
+  onExecuteDefaultQuery(database, table) {
     this.props.dispatch(QueryActions.executeDefaultSelectQueryIfNeeded(database.name, table.name));
   }
 
@@ -335,7 +335,7 @@ class QueryBrowserContainer extends Component {
                   functionsByDatabase={routines.functionsByDatabase}
                   proceduresByDatabase={routines.proceduresByDatabase}
                   onSelectDatabase={::this.onSelectDatabase}
-                  onDoubleClickTable={::this.onDoubleClickTable}
+                  onExecuteDefaultQuery={::this.onExecuteDefaultQuery}
                   onSelectTable={::this.onSelectTable}
                   onGetTableCreateScript={::this.onGetTableCreateScript}
                   onGetTableSelectScript={::this.onGetTableSelectScript}

--- a/src/renderer/reducers/index.js
+++ b/src/renderer/reducers/index.js
@@ -9,6 +9,7 @@ import views from './views';
 import routines from './routines';
 import columns from './columns';
 import triggers from './triggers';
+import sqlscripts from './sqlscripts';
 
 
 const rootReducer = combineReducers({
@@ -22,6 +23,7 @@ const rootReducer = combineReducers({
   routines,
   columns,
   triggers,
+  sqlscripts,
 });
 
 

--- a/src/renderer/reducers/routines.js
+++ b/src/renderer/reducers/routines.js
@@ -28,12 +28,14 @@ export default function (state = INITIAL_STATE, action) {
       functionsByDatabase: {
         ...state.functionsByDatabase,
         [action.database]: action.routines.filter(_isFunction).map(routine => ({
-          name: routine.routineName })),
+          name: routine.routineName,
+          routineDefinition: routine.routineDefinition })),
       },
       proceduresByDatabase: {
         ...state.proceduresByDatabase,
         [action.database]: action.routines.filter(_isProcedure).map(routine => ({
-          name: routine.routineName })),
+          name: routine.routineName,
+          routineDefinition: routine.routineDefinition })),
       },
       error: null,
     };

--- a/src/renderer/reducers/sqlscripts.js
+++ b/src/renderer/reducers/sqlscripts.js
@@ -40,7 +40,8 @@ export default function (state = INITIAL_STATE, action) {
           ...state.scriptsByObject[action.database],
           [action.table]: {
             ...scriptsByTable,
-            [action.scriptType]: action.script,
+            objectType: action.objectType,
+            [action.actionType]: action.script,
           },
         },
       },

--- a/src/renderer/reducers/sqlscripts.js
+++ b/src/renderer/reducers/sqlscripts.js
@@ -26,9 +26,9 @@ export default function (state = INITIAL_STATE, action) {
     };
   }
   case types.GET_SCRIPT_SUCCESS: {
-    const scriptsByTable = !state.scriptsByObject[action.database]
+    const scriptsByItem = !state.scriptsByObject[action.database]
       ? null
-      : state.scriptsByObject[action.database][action.table];
+      : state.scriptsByObject[action.database][action.item];
     return {
       ...state,
       isFetching: false,
@@ -38,8 +38,8 @@ export default function (state = INITIAL_STATE, action) {
         ...state.scriptsByObject,
         [action.database]: {
           ...state.scriptsByObject[action.database],
-          [action.table]: {
-            ...scriptsByTable,
+          [action.item]: {
+            ...scriptsByItem,
             objectType: action.objectType,
             [action.actionType]: action.script,
           },

--- a/src/renderer/reducers/sqlscripts.js
+++ b/src/renderer/reducers/sqlscripts.js
@@ -1,0 +1,59 @@
+import * as connTypes from '../actions/connections';
+import * as types from '../actions/sqlscripts';
+
+
+const INITIAL_STATE = {
+  isFetching: false,
+  didInvalidate: false,
+  scriptsByObject: {},
+};
+
+
+export default function (state = INITIAL_STATE, action) {
+  switch (action.type) {
+  case connTypes.CONNECTION_REQUEST: {
+    return action.isServerConnection
+      ? { ...INITIAL_STATE, didInvalidate: true }
+      : state;
+  }
+  case types.GET_SCRIPT_REQUEST: {
+    return {
+      ...state,
+      scriptType: action.scriptType,
+      isFetching: true,
+      didInvalidate: false,
+      error: null,
+    };
+  }
+  case types.GET_SCRIPT_SUCCESS: {
+    const scriptsByTable = !state.scriptsByObject[action.database]
+      ? null
+      : state.scriptsByObject[action.database][action.table];
+    return {
+      ...state,
+      isFetching: false,
+      didInvalidate: false,
+      error: null,
+      scriptsByObject: {
+        ...state.scriptsByObject,
+        [action.database]: {
+          ...state.scriptsByObject[action.database],
+          [action.table]: {
+            ...scriptsByTable,
+            [action.scriptType]: action.script,
+          },
+        },
+      },
+    };
+  }
+  case types.GET_SCRIPT_FAILURE: {
+    return {
+      ...state,
+      isFetching: false,
+      didInvalidate: true,
+      error: action.error,
+    };
+  }
+  default : return state;
+  }
+}


### PR DESCRIPTION
PR resolving (partially - not yet for routines) issue #125 .

So here it is in short:

- Database objects are now moved into `database-item.jsx` component because of context menu. I found this a cleanest solution, because context menu should be a property of database object (all links in menu are related exclusively to that object).

- Context menu is built dynamically [here](https://github.com/BornaP/sqlectron-gui/blob/125-objects-sql-definitions/src/renderer/components/database-item.jsx#L35) .Reason, as explained in comment in a code, is that there's no need to built context menu for each object (table/view) before it's needed, it just slows down application, especially when loading big number of objects (test on db with 130 tables, it took 2 secs). This way is much faster and neater.

- @maxcnunes Here I need your opinion, whether to keep fetching scripts (SQL definitions) in separate functions (like its now, every scripts has it's own implementation in `actions/sqlscripts.js`) or make unique one (i.e. getScriptIfNeeded) and pass script type (I guess this would be a object, i.e. `{ type: 'create', item: 'table' }` ) as a parameter to single function (something like this getScriptIfNeeded (database, table, scriptNeeded) ). Then we would have if-else clause which would call on a database (sqlectron-core) API, depending on the parameter passed.  I know this is probably anti-pattern, but it would be much less code than it is now, and only one event handler function would be passed to components (now we have like 7).

- Context menu for routines not implemented yet. Should be fairly simple, because they are already fetched in store routines object.