### PR TITLE
Fix table rows scaling long texts

### DIFF
--- a/src/renderer/components/query-result-table.scss
+++ b/src/renderer/components/query-result-table.scss
@@ -19,4 +19,11 @@
       }
     }
   }
+
+  td {
+    max-width: 220px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }


### PR DESCRIPTION
Pull request that resolves issue #126 

Table rows now have always the same height as long texts are not broken into more lines anymore. After certain number of chars, '...' is appended instead of the rest of the text. I've put fixed `max-width ` to 220 pixels, because I found out that corresponds to the same maximum number of characters shown in table cell in MySQL Workbench (which I took as a example). That can be changed if someone has better suggestion.

How it looked before:
![table-sqlectron](https://cloud.githubusercontent.com/assets/8470710/15251606/83ce3e26-192a-11e6-927b-bdb5239caf38.png)

How it looks now:
![fixed_table_cell_scaling](https://cloud.githubusercontent.com/assets/8470710/15251849/9cb4f69a-192b-11e6-8147-5a6fb53b70a0.png)

I haven't implemented modal that @krolow suggested in the issue, because @maxcnunes proposed using [FixedDataTable](https://facebook.github.io/fixed-data-table/) where columns can be resized so user would be able to see full text that way (that's how many others SQL client's work). Also, full text/string can be selected by simple double clicking the cell value. So in that perspective, opening modal on double click is redundant.