### PR TITLE
Append query script instead of updating whole query editor

### DIFF
--- a/src/renderer/actions/queries.js
+++ b/src/renderer/actions/queries.js
@@ -91,6 +91,17 @@ function shouldUpdateQuery (query, selectedQuery, state) {
   return true;
 }
 
+export function appendQuery (query) {
+  return (dispatch, getState) => {
+    const currentQuery = getCurrentQuery(getState()).query;
+    const newLine = !currentQuery ? '' : '\n';
+    const appendedQuery = `${currentQuery}${newLine}${query}`;
+    if (!currentQuery.isExecuting){
+      return dispatch(updateQuery(appendedQuery));
+    }
+  };
+}
+
 
 export function copyToClipboard (rows, type) {
   return async dispatch => {

--- a/src/renderer/actions/sqlscripts.js
+++ b/src/renderer/actions/sqlscripts.js
@@ -1,5 +1,5 @@
 import { getDBConnByName } from './connections';
-import { updateQueryIfNeeded } from './queries';
+import { appendQuery } from './queries';
 
 
 export const GET_SCRIPT_REQUEST = 'GET_SCRIPT_REQUEST';
@@ -14,7 +14,7 @@ export function getSQLScriptIfNeeded(database, item, actionType, objectType) {
       return dispatch(getSQLScript(database, item, actionType, objectType));
     } else if (isScriptAlreadyFetched(state, database, item, actionType)) {
       const script = getAlreadyFetchedScript(state, database, item, actionType);
-      return dispatch(updateQueryIfNeeded(script));
+      return dispatch(appendQuery(script));
     }
   };
 }
@@ -64,7 +64,7 @@ function getSQLScript (database, item, actionType, objectType) {
         script = await dbConn.getTableDeleteScript(item);
       }
       dispatch({ type: GET_SCRIPT_SUCCESS, database, item, script, actionType, objectType });
-      dispatch(updateQueryIfNeeded(script));
+      dispatch(appendQuery(script));
     } catch (error) {
       dispatch({ type: GET_SCRIPT_FAILURE, error });
     }


### PR DESCRIPTION
Explained here: [#141 (comment)](https://github.com/sqlectron/sqlectron-gui/pull/141#issuecomment-218437013)

Instead of removing previous query with selected SQL script, script is now appended in new row to query editor.