### PR TITLE
Change to new way electron modules are required for easier upgrade

### DIFF
--- a/src/browser/app.js
+++ b/src/browser/app.js
@@ -1,5 +1,4 @@
-import app from 'app';
-import { dialog } from 'electron';
+import { app, dialog } from 'electron';
 import { buildNewWindow } from './window';
 
 

--- a/src/browser/menu/darwin.js
+++ b/src/browser/menu/darwin.js
@@ -1,4 +1,4 @@
-import shell from 'shell';
+import { shell } from 'electron';
 
 export function buildTemplate(app, buildNewWindow, appConfig) {
   return [

--- a/src/browser/menu/index.js
+++ b/src/browser/menu/index.js
@@ -1,4 +1,4 @@
-import Menu from 'menu';
+import { Menu } from 'electron';
 
 
 const menus = {

--- a/src/browser/menu/linux.js
+++ b/src/browser/menu/linux.js
@@ -1,4 +1,4 @@
-import shell from 'shell';
+import { shell } from 'electron';
 
 
 export function buildTemplate(app, buildNewWindow, appConfig) {

--- a/src/browser/menu/win32.js
+++ b/src/browser/menu/win32.js
@@ -1,4 +1,4 @@
-import shell from 'shell';
+import { shell } from 'electron';
 
 
 export function buildTemplate(app, buildNewWindow, appConfig) {

--- a/src/browser/remote.js
+++ b/src/browser/remote.js
@@ -1,4 +1,4 @@
-import remote from 'remote';
+import { remote } from 'electron';
 
 
 /**

--- a/src/browser/window.js
+++ b/src/browser/window.js
@@ -1,5 +1,5 @@
 import { resolve } from 'path';
-import BrowserWindow from 'browser-window';
+import { BrowserWindow } from 'electron';
 import { attachMenuToWindow } from './menu';
 import { check as checkUpdate } from './update-checker';
 import { get as getConfig } from './config';

--- a/src/renderer/components/database-item.jsx
+++ b/src/renderer/components/database-item.jsx
@@ -1,6 +1,9 @@
 import React, { Component, PropTypes } from 'react';
 import TableSubmenu from './table-submenu.jsx';
-import { Menu, MenuItem } from 'remote';
+import { remote } from 'electron';
+
+const Menu = remote.Menu;
+const MenuItem = remote.MenuItem;
 
 
 const STYLE = {

--- a/src/renderer/components/footer.jsx
+++ b/src/renderer/components/footer.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import shell from 'shell';
+import { shell } from 'electron';
 import UpdateChecker from './update-checker.jsx';
 
 

--- a/src/renderer/components/header.jsx
+++ b/src/renderer/components/header.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import shell from 'shell';
+import { shell } from 'electron';
 
 require('./header.css');
 

--- a/src/renderer/components/update-checker.jsx
+++ b/src/renderer/components/update-checker.jsx
@@ -1,5 +1,5 @@
 import { ipcRenderer } from 'electron';
-import shell from 'shell';
+import { shell } from 'electron';
 import React, {Component} from 'react';
 
 


### PR DESCRIPTION
Leave deprecated API and support new one. [Electron API changes](http://electron.atom.io/blog/2015/11/17/electron-api-changes). 

This change does not affect app behavior (it works with current v0.36.12), but is necessary for upgrade to v1.x.x.

Ready for squash&merge.