### PR TITLE
Add search shortcuts (resolves #152)

### DIFF
--- a/src/browser/menu/darwin.js
+++ b/src/browser/menu/darwin.js
@@ -135,6 +135,21 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
       ],
     },
     {
+      label: 'Find',
+      submenu: [
+        {
+          label: 'Search databases',
+          accelerator: 'Cmd+F',
+          click: (item, win) => win.webContents.send('sqlectron:toggle-database-search'),
+        },
+        {
+          label: 'Search database objects',
+          accelerator: 'Alt+Cmd+F',
+          click: (item, win) => win.webContents.send('sqlectron:toggle-database-objects-search'),
+        }
+      ],
+    },
+    {
       label: 'Window',
       submenu: [
         {
@@ -174,4 +189,3 @@ export function buildTemplateDockMenu(app, buildNewWindow) {
     { label: 'New Window', click: () => buildNewWindow(app) },
   ];
 }
-

--- a/src/browser/menu/linux.js
+++ b/src/browser/menu/linux.js
@@ -103,6 +103,21 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
       ],
     },
     {
+      label: 'Find',
+      submenu: [
+        {
+          label: 'Search databases',
+          accelerator: 'Ctrl+F',
+          click: (item, win) => win.webContents.send('sqlectron:toggle-database-search'),
+        },
+        {
+          label: 'Search database objects',
+          accelerator: 'Alt+Ctrl+F',
+          click: (item, win) => win.webContents.send('sqlectron:toggle-database-objects-search'),
+        }
+      ],
+    },
+    {
       label: 'Help',
       submenu: [
         {

--- a/src/browser/menu/win32.js
+++ b/src/browser/menu/win32.js
@@ -103,6 +103,21 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
       ],
     },
     {
+      label: 'Find',
+      submenu: [
+        {
+          label: 'Search databases',
+          accelerator: 'Ctrl+F',
+          click: (item, win) => win.webContents.send('sqlectron:toggle-database-search'),
+        },
+        {
+          label: 'Search database objects',
+          accelerator: 'Alt+Ctrl+F',
+          click: (item, win) => win.webContents.send('sqlectron:toggle-database-objects-search'),
+        }
+      ],
+    },
+    {
       label: 'Help',
       submenu: [
         {

--- a/src/renderer/components/database-filter.jsx
+++ b/src/renderer/components/database-filter.jsx
@@ -5,7 +5,14 @@ export default class DatabaseFilter extends Component {
   static propTypes = {
     value: PropTypes.string,
     isFetching: PropTypes.bool.isRequired,
+    focusSearch: PropTypes.bool,
     onFilterChange: PropTypes.func.isRequired,
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.focusSearch !== nextProps.focusSearch) {
+      this.refs.searchInput.focus();
+    }
   }
 
   onFilterChange(event) {
@@ -19,6 +26,7 @@ export default class DatabaseFilter extends Component {
         <input type="text"
           placeholder="Search..."
           value={value}
+          ref="searchInput"
           onChange={::this.onFilterChange} />
         <i className="search icon"></i>
       </div>

--- a/src/renderer/components/database-list-item.jsx
+++ b/src/renderer/components/database-list-item.jsx
@@ -40,6 +40,15 @@ export default class DatabaseListItem extends Component {
     this.state = {};
   }
 
+  componentWillReceiveProps(nextProps) {
+    // If search is toggled for certain database that is collapsed then toggle collapse.
+    if (this.state.collapsed &&
+      this.props.focusSearch !== nextProps.focusSearch){
+
+      this.toggleCollapse();
+    }
+  }
+
   onFilterChange(value) {
     this.setState({ filter: value });
   }

--- a/src/renderer/components/database-list-item.jsx
+++ b/src/renderer/components/database-list-item.jsx
@@ -28,6 +28,7 @@ export default class DatabaseListItem extends Component {
     functions: PropTypes.array,
     procedures: PropTypes.array,
     database: PropTypes.object.isRequired,
+    focusSearch: PropTypes.bool,
     onExecuteDefaultQuery: PropTypes.func.isRequired,
     onSelectTable: PropTypes.func.isRequired,
     onSelectDatabase: PropTypes.func.isRequired,
@@ -93,6 +94,7 @@ export default class DatabaseListItem extends Component {
       functions,
       procedures,
       database,
+      focusSearch,
       onExecuteDefaultQuery,
       onSelectTable,
       onGetSQLScript,
@@ -121,6 +123,7 @@ export default class DatabaseListItem extends Component {
           <div className="item" style={cssStyleItems}>
             <DatabaseFilter
               value={filter}
+              focusSearch={focusSearch}
               isFetching={!isMetadataLoaded}
               onFilterChange={::this.onFilterChange} />
           </div>

--- a/src/renderer/components/database-list.jsx
+++ b/src/renderer/components/database-list.jsx
@@ -12,6 +12,7 @@ export default class DatabaseList extends Component {
     viewsByDatabase: PropTypes.object.isRequired,
     functionsByDatabase: PropTypes.object.isRequired,
     proceduresByDatabase: PropTypes.object.isRequired,
+    toggleSearch: PropTypes.object,
     onSelectDatabase: PropTypes.func.isRequired,
     onExecuteDefaultQuery: PropTypes.func.isRequired,
     onSelectTable: PropTypes.func.isRequired,
@@ -33,6 +34,7 @@ export default class DatabaseList extends Component {
       viewsByDatabase,
       functionsByDatabase,
       proceduresByDatabase,
+      toggleSearch,
       onExecuteDefaultQuery,
       onSelectTable,
       onSelectDatabase,
@@ -64,6 +66,7 @@ export default class DatabaseList extends Component {
             views={viewsByDatabase[database.name]}
             functions={functionsByDatabase[database.name]}
             procedures={proceduresByDatabase[database.name]}
+            focusSearch={toggleSearch ? toggleSearch[database.name] : undefined}
             onExecuteDefaultQuery={onExecuteDefaultQuery}
             onSelectTable={onSelectTable}
             onSelectDatabase={onSelectDatabase}

--- a/src/renderer/containers/query-browser.jsx
+++ b/src/renderer/containers/query-browser.jsx
@@ -161,6 +161,8 @@ class QueryBrowserContainer extends Component {
       'sqlectron:new-tab': () => this.newTab(),
       'sqlectron:close-tab': () => this.closeTab(),
       'sqlectron:save-query': () => this.saveQuery(),
+      'sqlectron:toggle-database-search': () => this.toggleDatabaseSearch(),
+      'sqlectron:toggle-database-objects-search': () => this.toggleDatabaseObjectsSearch(),
     });
   }
 
@@ -188,6 +190,21 @@ class QueryBrowserContainer extends Component {
   filterDatabases(name, databases) {
     const regex = RegExp(name, 'i');
     return databases.filter(db => regex.test(db.name));
+  }
+
+  toggleDatabaseSearch() {
+    this.setState({ toggleDatabaseSearch: !this.state.toggleDatabaseSearch });
+  }
+
+  toggleDatabaseObjectsSearch() {
+    const state = { ...this.state };
+    const currentDB = this.getCurrentQuery().database;
+    if (!currentDB) return;
+    if (!state.toggleSearch) {
+      state.toggleSearch = {};
+    }
+    state.toggleSearch[currentDB] = !state.toggleSearch[currentDB];
+    this.setState(state);
   }
 
   newTab() {
@@ -261,7 +278,7 @@ class QueryBrowserContainer extends Component {
   }
 
   render() {
-    const { filter } = this.state;
+    const { filter, toggleDatabaseSearch, toggleSearch } = this.state;
     const {
       status,
       connections,
@@ -308,6 +325,7 @@ class QueryBrowserContainer extends Component {
                   <DatabaseFilter
                     value={filter}
                     isFetching={databases.isFetching}
+                    focusSearch={toggleDatabaseSearch}
                     onFilterChange={::this.onFilterChange} />
                 </div>
                 <DatabaseList
@@ -319,6 +337,7 @@ class QueryBrowserContainer extends Component {
                   viewsByDatabase={views.viewsByDatabase}
                   functionsByDatabase={routines.functionsByDatabase}
                   proceduresByDatabase={routines.proceduresByDatabase}
+                  toggleSearch={toggleSearch}
                   onSelectDatabase={::this.onSelectDatabase}
                   onExecuteDefaultQuery={::this.onExecuteDefaultQuery}
                   onSelectTable={::this.onSelectTable}


### PR DESCRIPTION
Search shortcuts added to menu:

| Windows/Linux                  | Mac                            | Action                         |
|:-------------------------------|:-------------------------------|:-------------------------------|
| Ctrl+F | Command+F | Focus database search |
| Alt+Ctrl+F | Alt+Command+F | Focus database object search |

`Alt+Ctrl+F` focuses search on database that is currently active on query tab. If database connection is not opened or specified (i.e. user has lost focus from query area), command will be ignored. That's because current database name is needed so it can be resolved which search input to focus.

There's bug currently which I couldn't solve easily. When database search is focus, trying to focus database object search by keyboard does not react. I tried with setting all `toggle{Database}Search` states (expect the one triggered) to false, and act accordingly (i.e. on `nextProps.focusSerach === false` trigger blur, on `nextProps.focusSearch === true` trigger focus on input). But it did not work, it seemed like blur did nothing. 