### PR TITLE
Upgrade to electron stable major, v1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "denodeify": "^1.2.1",
     "electron-builder": "next",
     "electron-packager": "^5.2.1",
-    "electron-prebuilt": "^0.36.12",
+    "electron-prebuilt": "^1.1.2",
     "eslint": "^1.7.3",
     "eslint-config-airbnb": "^0.1.0",
     "eslint-plugin-react": "^3.15.0",


### PR DESCRIPTION
Finally, major version that works for us! :tada: 

Promises are now handled properly. There are bunch of warnings thrown in console but I guess they are related to Chrome v50.0.x, since I noticed them as of electron v1.1.0 which was bump to newer Chrome version. App works as expected anyways! :)

Since minor changes related to migrating to new API were already implemented in 131bf85154c3f976553a669f373695d58dc05049, this upgrade did not need any additional changes.