### PR TITLE
Add support for private key passphrase

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -20,6 +20,6 @@
     "babel-core": "^5.8.29",
     "babel-runtime": "^5.8.29",
     "debug": "^2.2.0",
-    "sqlectron-core": "^4.0.0"
+    "sqlectron-core": "^6.0.0"
   }
 }

--- a/src/renderer/actions/connections.js
+++ b/src/renderer/actions/connections.js
@@ -5,6 +5,7 @@ export const CLOSE_CONNECTION = 'CLOSE_CONNECTION';
 export const CONNECTION_REQUEST = 'CONNECTION_REQUEST';
 export const CONNECTION_SUCCESS = 'CONNECTION_SUCCESS';
 export const CONNECTION_FAILURE = 'CONNECTION_FAILURE';
+export const CONNECTION_REQUIRE_SSH_PASSWORD = 'CONNECTION_REQUIRE_SSH_PASSWORD';
 export const TEST_CONNECTION_REQUEST = 'TEST_CONNECTION_REQUEST';
 export const TEST_CONNECTION_SUCCESS = 'TEST_CONNECTION_SUCCESS';
 export const TEST_CONNECTION_FAILURE = 'TEST_CONNECTION_FAILURE';
@@ -39,7 +40,7 @@ export function getDBConnByName(database) {
 }
 
 
-export function connect (id, databaseName, reconnecting = false) {
+export function connect (id, databaseName, reconnecting = false, sshPassphrase) {
   return async (dispatch, getState) => {
     let server;
     let dbConn;
@@ -60,6 +61,15 @@ export function connect (id, databaseName, reconnecting = false) {
       dispatch({ type: CONNECTION_REQUEST, server, database, reconnecting, isServerConnection: !databaseName });
 
       if (!serverSession) {
+        if (server.ssh.privateKeyWithPassphrase && typeof sshPassphrase === 'undefined') {
+          dispatch({ type: CONNECTION_REQUIRE_SSH_PASSWORD });
+          return;
+        }
+
+        if (server.ssh.privateKeyWithPassphrase) {
+          server.ssh.passphrase = sshPassphrase;
+        }
+
         serverSession = sqlectron.db.createServer(server);
       }
 
@@ -91,8 +101,12 @@ export function connect (id, databaseName, reconnecting = false) {
 
 
 export function disconnect () {
-  serverSession.end();
+  if (serverSession) {
+    serverSession.end();
+  }
+
   serverSession = null;
+
   return { type: CLOSE_CONNECTION };
 }
 

--- a/src/renderer/components/prompt-modal.jsx
+++ b/src/renderer/components/prompt-modal.jsx
@@ -1,0 +1,59 @@
+import React, { Component, PropTypes } from 'react';
+
+
+export default class PromptModal extends Component {
+  static propTypes = {
+    onCancelClick: PropTypes.func.isRequired,
+    onOKClick: PropTypes.func.isRequired,
+    title: PropTypes.string.isRequired,
+    message: PropTypes.string.isRequired,
+    type: PropTypes.string.isRequired,
+  }
+
+  componentDidMount() {
+    $(this.refs.promptModal).modal({
+      closable: false,
+      detachable: false,
+      onDeny: () => {
+        this.props.onCancelClick();
+        return true;
+      },
+      onApprove: () => {
+        this.props.onOKClick(this.refs.text.value);
+        return false;
+      },
+    }).modal('show');
+  }
+
+  componentWillUnmount() {
+    $(this.refs.promptModal).modal('hide');
+  }
+
+  render() {
+    const { title, message, type } = this.props;
+
+    return (
+      <div className="ui modal" ref="promptModal">
+        <div className="header">
+          {title}
+        </div>
+        <div className="content">
+          {message}
+          <div className="ui fluid icon input">
+            <input ref="text" type={type} />
+          </div>
+        </div>
+        <div className="actions">
+          <div className="small ui black deny right labeled icon button" tabIndex="0">
+            Cancel
+            <i className="ban icon"></i>
+          </div>
+          <div className="small ui positive right labeled icon button" tabIndex="0">
+            OK
+            <i className="checkmark icon"></i>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/renderer/components/server-modal-form.jsx
+++ b/src/renderer/components/server-modal-form.jsx
@@ -60,6 +60,19 @@ export default class ServerModalForm extends Component {
       onChecked: () => this.setState({ ssl: true }),
       onUnchecked: () => this.setState({ ssl: false }),
     });
+
+    $(this.refs.privateKeyWithPassphrase).checkbox({
+      onChecked: () => {
+        const ssh = this.state.ssh ? { ...this.state.ssh } : {};
+        ssh.privateKeyWithPassphrase = true;
+        this.setState({ ssh });
+      },
+      onUnchecked: () => {
+        const ssh = this.state.ssh ? { ...this.state.ssh } : {};
+        ssh.privateKeyWithPassphrase = false;
+        this.setState({ ssh });
+      },
+    });
   }
 
   componentWillReceiveProps(nextProps) {
@@ -124,6 +137,7 @@ export default class ServerModalForm extends Component {
       user: ssh.user,
       password: ssh.password && ssh.password.length ? ssh.password : null,
       privateKey: ssh.privateKey && ssh.privateKey.length ? ssh.privateKey : null,
+      privateKeyWithPassphrase: !!ssh.privateKeyWithPassphrase,
     };
 
     return server;
@@ -341,7 +355,7 @@ export default class ServerModalForm extends Component {
                 </div>
               </div>
               <div className="fields">
-                <div className={`five wide field ${this.highlightError('ssh.user')}`}>
+                <div className={`four wide field ${this.highlightError('ssh.user')}`}>
                   <label>User</label>
                   <input type="text"
                     name="ssh.user"
@@ -351,7 +365,7 @@ export default class ServerModalForm extends Component {
                     value={ssh.user}
                     onChange={::this.handleChange} />
                 </div>
-                <div className={`five wide field ${this.highlightError('ssh.password')}`}>
+                <div className={`four wide field ${this.highlightError('ssh.password')}`}>
                   <label>Password</label>
                   <input type="password"
                     name="ssh.password"
@@ -361,7 +375,7 @@ export default class ServerModalForm extends Component {
                     value={ssh.password}
                     onChange={::this.handleChange} />
                 </div>
-                <div className={`six wide field ${this.highlightError('ssh.privateKey')}`}>
+                <div className={`five wide field ${this.highlightError('ssh.privateKey')}`}>
                   <label>Private Key</label>
                   <div className="ui action input">
                     <input type="text"
@@ -380,6 +394,17 @@ export default class ServerModalForm extends Component {
                          onChange={::this.handleChange}
                          style={{display: 'none'}} />
                     </label>
+                  </div>
+                </div>
+                <div className="three wide field" style={{paddingTop: '2em'}}>
+                  <div className="ui toggle checkbox" ref="privateKeyWithPassphrase">
+                    <input type="checkbox"
+                      name="privateKeyWithPassphrase"
+                      tabIndex="0"
+                      className="hidden"
+                      disabled={(!isSSHChecked || ssh.password)}
+                      defaultChecked={this.state.ssh && this.state.ssh.privateKeyWithPassphrase} />
+                    <label>Passphrase</label>
                   </div>
                 </div>
               </div>

--- a/src/renderer/containers/query-browser.jsx
+++ b/src/renderer/containers/query-browser.jsx
@@ -18,6 +18,7 @@ import Header from '../components/header.jsx';
 import Footer from '../components/footer.jsx';
 import Query from '../components/query.jsx';
 import Loader from '../components/loader.jsx';
+import PromptModal from '../components/prompt-modal.jsx';
 import MenuHandler from '../menu-handler';
 
 
@@ -83,7 +84,7 @@ class QueryBrowserContainer extends Component {
   componentWillReceiveProps (nextProps) {
     const { dispatch, history, connections } = nextProps;
 
-    if (connections.error || (!connections.connecting && !connections.server)) {
+    if (connections.error || (!connections.connecting && !connections.server && !connections.waitingSSHPassword)) {
       history.pushState(null, '/');
       return;
     }
@@ -114,6 +115,16 @@ class QueryBrowserContainer extends Component {
 
   onExecuteDefaultQuery(database, table) {
     this.props.dispatch(QueryActions.executeDefaultSelectQueryIfNeeded(database.name, table.name));
+  }
+
+  onPromptCancelClick() {
+    const { dispatch } = this.props;
+    dispatch(ConnActions.disconnect());
+  }
+
+  onPromptOKClick(password) {
+    const { dispatch, params } = this.props;
+    dispatch(ConnActions.connect(params.id, null, false, password));
   }
 
   onSelectTable(database, table) {
@@ -303,6 +314,17 @@ class QueryBrowserContainer extends Component {
       views,
       routines,
     } = this.props;
+
+    if (connections.waitingPrivateKeyPassphrase) {
+      return (
+        <PromptModal
+          type="password"
+          title={`SSH Private Key Passphrase`}
+          message="Enter the private key passphrase:"
+          onCancelClick={::this.onPromptCancelClick}
+          onOKClick={::this.onPromptOKClick} />
+      );
+    }
 
     const isLoading = (!connections.connected);
     if (isLoading && (!connections.server || !this.getCurrentQuery())) {

--- a/src/renderer/reducers/connections.js
+++ b/src/renderer/reducers/connections.js
@@ -6,6 +6,7 @@ const INITIAL_STATE = {
   connected: false,
   connecting: false,
   server: null,
+  waitingPrivateKeyPassphrase: false,
   databases: [], // connected databases
 };
 
@@ -15,11 +16,15 @@ export default function(state = INITIAL_STATE, action) {
   case types.CONNECTION_REQUEST: {
     return { ...INITIAL_STATE, server: action.server };
   }
+  case types.CONNECTION_REQUIRE_SSH_PASSWORD: {
+    return { ...state, waitingPrivateKeyPassphrase: true };
+  }
   case types.CONNECTION_SUCCESS: {
     return {
       ...state,
       connected: true,
       connecting: false,
+      waitingPrivateKeyPassphrase: false,
       databases: [
         ...state.databases,
         action.database,
@@ -27,7 +32,13 @@ export default function(state = INITIAL_STATE, action) {
     };
   }
   case types.CONNECTION_FAILURE: {
-    return { ...state, connected: false, connecting: false, error: action.error };
+    return {
+      ...state,
+      connected: false,
+      connecting: false,
+      waitingPrivateKeyPassphrase: false,
+      error: action.error,
+    };
   }
   case types.TEST_CONNECTION_REQUEST: {
     const { server } = action;


### PR DESCRIPTION
Show a prompt modal asking for the private key passphrase in case the user has checked the "Passphrase" checkbox in the server configuration.

Close #155.

Close #117 as well since have upgrade sqlectron-core which has the fixing for that bug.