### PR TITLE
Feature: Add related tables on right click

### DIFF
--- a/src/renderer/components/database-diagram-modal.jsx
+++ b/src/renderer/components/database-diagram-modal.jsx
@@ -17,6 +17,7 @@ export default class DatabaseDiagramModal extends Component {
     tableKeys: PropTypes.object,
     diagramJSON: PropTypes.string,
     onGenerateDatabaseDiagram: PropTypes.func.isRequired,
+    addRelatedTables: PropTypes.func.isRequired,
     onSaveDatabaseDiagram: PropTypes.func.isRequired,
     onOpenDatabaseDiagram: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired,
@@ -64,6 +65,18 @@ export default class DatabaseDiagramModal extends Component {
   onGenerateDiagramClick() {
     this.setState({ showLoader: true });
     this.props.onGenerateDatabaseDiagram(this.props.database);
+  }
+
+  onAddRelatedTables(relatedTables) {
+    const { selectedTables, addRelatedTables } = this.props;
+
+    // If all related tables are already on diagram -> no need to reset positions
+    if (relatedTables.every(t => selectedTables.includes(t))) {
+      return;
+    }
+
+    this.setState({  showDatabaseDiagram: false });
+    addRelatedTables(relatedTables);
   }
 
   showDiagramIfNeeded(props) {
@@ -147,7 +160,13 @@ export default class DatabaseDiagramModal extends Component {
   }
 
   renderDiagram() {
-    const { selectedTables, columnsByTable, tableKeys, diagramJSON } = this.props;
+    const {
+      selectedTables,
+      columnsByTable,
+      tableKeys,
+      diagramJSON,
+      onAddRelatedTables,
+    } = this.props;
 
     return (
       <DatabaseDiagram
@@ -155,7 +174,8 @@ export default class DatabaseDiagramModal extends Component {
         tables={selectedTables}
         columnsByTable={columnsByTable}
         tableKeys={tableKeys}
-        diagramJSON={diagramJSON} />
+        diagramJSON={diagramJSON}
+        addRelatedTables={::this.onAddRelatedTables} />
     );
   }
 

--- a/src/renderer/components/database-diagram.jsx
+++ b/src/renderer/components/database-diagram.jsx
@@ -167,7 +167,13 @@ export default class DatabaseDiagram extends Component {
   }
 
   onTableDoubleClick(table) {
-    const { tableKeys, addRelatedTables } = this.props;
+    const { tableKeys, diagramJSON, addRelatedTables } = this.props;
+
+    // Currently not supported for diagram loaded from file
+    if (diagramJSON) {
+      return;
+    }
+
     const relatedTables = tableKeys[table].map(k => k.referencedTable).filter(rt => rt !== null);
     addRelatedTables(relatedTables);
   }

--- a/src/renderer/components/database-diagram.jsx
+++ b/src/renderer/components/database-diagram.jsx
@@ -56,12 +56,14 @@ export default class DatabaseDiagram extends Component {
       restrictTranslate: true,
     });
 
-    this.paper.on('cell:pointerdblclick',
-      (cellView, evt, x, y) => {
-        const table = cellView.model.attributes.name;
-        this.onTableDoubleClick(table);
-      }
-    );
+    if (!this.props.diagramJSON) { //Only supported for newely generated diagrams
+      this.paper.on('cell:contextmenu',
+        (cellView, evt, x, y) => {
+          const table = cellView.model.attributes.name;
+          this.onTableRightClick(table);
+        }
+      );
+    }
   }
 
   generateTableElements(tableShapes, tableCells) {
@@ -166,14 +168,8 @@ export default class DatabaseDiagram extends Component {
     });
   }
 
-  onTableDoubleClick(table) {
-    const { tableKeys, diagramJSON, addRelatedTables } = this.props;
-
-    // Currently not supported for diagram loaded from file
-    if (diagramJSON) {
-      return;
-    }
-
+  onTableRightClick(table) {
+    const { tableKeys, addRelatedTables } = this.props;
     const relatedTables = tableKeys[table].map(k => k.referencedTable).filter(rt => rt !== null);
     addRelatedTables(relatedTables);
   }

--- a/src/renderer/components/database-diagram.jsx
+++ b/src/renderer/components/database-diagram.jsx
@@ -13,6 +13,7 @@ export default class DatabaseDiagram extends Component {
     columnsByTable: PropTypes.object,
     tableKeys: PropTypes.object,
     diagramJSON: PropTypes.string,
+    addRelatedTables: PropTypes.func.isRequired,
   }
 
   constructor(props) {
@@ -54,6 +55,13 @@ export default class DatabaseDiagram extends Component {
       gridSize: 1,
       restrictTranslate: true,
     });
+
+    this.paper.on('cell:pointerdblclick',
+      (cellView, evt, x, y) => {
+        const table = cellView.model.attributes.name;
+        this.onTableDoubleClick(table);
+      }
+    );
   }
 
   generateTableElements(tableShapes, tableCells) {
@@ -156,6 +164,12 @@ export default class DatabaseDiagram extends Component {
           .map((cell) => cell.resize( biggestCellSize, 20 ));
       }
     });
+  }
+
+  onTableDoubleClick(table) {
+    const { tableKeys, addRelatedTables } = this.props;
+    const relatedTables = tableKeys[table].map(k => k.referencedTable).filter(rt => rt !== null);
+    addRelatedTables(relatedTables);
   }
 
   render() {

--- a/src/renderer/containers/query-browser.jsx
+++ b/src/renderer/containers/query-browser.jsx
@@ -1,4 +1,4 @@
-import { debounce } from 'lodash';
+import { debounce, union } from 'lodash';
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
@@ -191,6 +191,20 @@ class QueryBrowserContainer extends Component {
     });
   }
 
+  onAddRelatedTables(relatedTables) {
+    const { dispatch, databases, tables } = this.props;
+    const database = databases.diagramDatabase;
+    const tablesOnDiagram = tables.selectedTablesForDiagram;
+    const selectedTables = union(tablesOnDiagram, relatedTables);
+
+    dispatch(selectTablesForDiagram(selectedTables));
+
+    relatedTables.map((item) => {
+      dispatch(fetchTableColumnsIfNeeded(database, item));
+      dispatch(fetchTableKeysIfNeeded(database, item));
+    });
+  }
+
   onSaveDatabaseDiagram(diagram) {
     this.props.dispatch(DbAction.saveDatabaseDiagram(diagram));
   }
@@ -300,6 +314,7 @@ class QueryBrowserContainer extends Component {
         tableKeys={keys.keysByTable[selectedDB]}
         diagramJSON={databases.diagramJSON}
         onGenerateDatabaseDiagram={::this.onGenerateDatabaseDiagram}
+        addRelatedTables={::this.onAddRelatedTables}
         onSaveDatabaseDiagram={::this.onSaveDatabaseDiagram}
         onOpenDatabaseDiagram={::this.onOpenDatabaseDiagram}
         onClose={::this.onCloseDiagramModal} />

--- a/src/renderer/containers/query-browser.jsx
+++ b/src/renderer/containers/query-browser.jsx
@@ -184,11 +184,7 @@ class QueryBrowserContainer extends Component {
     });
 
     dispatch(selectTablesForDiagram(selectedTables));
-
-    selectedTables.map((item) => {
-      dispatch(fetchTableColumnsIfNeeded(database, item));
-      dispatch(fetchTableKeysIfNeeded(database, item));
-    });
+    this.fetchTableDiagramData(database, selectedTables);
   }
 
   onAddRelatedTables(relatedTables) {
@@ -198,8 +194,12 @@ class QueryBrowserContainer extends Component {
     const selectedTables = union(tablesOnDiagram, relatedTables);
 
     dispatch(selectTablesForDiagram(selectedTables));
+    this.fetchTableDiagramData(database, relatedTables);
+  }
 
-    relatedTables.map((item) => {
+  fetchTableDiagramData(database, tables) {
+    const { dispatch } = this.props;
+    tables.map((item) => {
       dispatch(fetchTableColumnsIfNeeded(database, item));
       dispatch(fetchTableKeysIfNeeded(database, item));
     });


### PR DESCRIPTION
Added feature that enables user to automatically add related tables when (s)he right clicks on a table while making diagram.

This does not work with diagrams loaded from files at the moment.

How it works (captured just a part of the screen):
![related-tab](https://cloud.githubusercontent.com/assets/8470710/16006409/4afddbb4-316d-11e6-9f95-25adc48453bb.gif)

Ignore the colors, screen capturing tool messed them up a bit.

