### PR TITLE
Export diagram to image format - .png and .jpeg

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "fixed-data-table": "^0.6.0",
     "history": "^1.12.6",
     "html-webpack-plugin": "^2.19.0",
+    "html2canvas": "^0.5.0-beta4",
     "imports-loader": "^0.6.5",
     "jointjs": "^0.9.9",
     "jquery": "^2.2.0",

--- a/src/renderer/actions/databases.js
+++ b/src/renderer/actions/databases.js
@@ -68,10 +68,6 @@ export function exportDatabaseDiagram(diagram, imageType) {
   return async (dispatch) => {
     dispatch({ type: EXPORT_DIAGRAM_REQUEST });
     try {
-      // fix - reapply css roles which html2canvas ignores for some reason
-      $('.link-tools, .marker-arrowheads', diagram).css({ display: 'none' });
-      $('.link, .connection', diagram).css({ fill: 'none' });
-
       // html2canvas library only captures elements in window view
       diagram.scrollIntoView();
 

--- a/src/renderer/actions/databases.js
+++ b/src/renderer/actions/databases.js
@@ -1,4 +1,5 @@
 import path from 'path';
+import html2canvas from 'html2canvas';
 import { getCurrentDBConn } from './connections';
 import * as FileHandler from '../utils/file-handler';
 
@@ -17,6 +18,9 @@ export const SAVE_DIAGRAM_FAILURE = 'SAVE_DIAGRAM_FAILURE';
 export const OPEN_DIAGRAM_REQUEST = 'OPEN_DIAGRAM_REQUEST';
 export const OPEN_DIAGRAM_SUCCESS = 'OPEN_DIAGRAM_SUCCESS';
 export const OPEN_DIAGRAM_FAILURE = 'OPEN_DIAGRAM_FAILURE';
+export const EXPORT_DIAGRAM_REQUEST = 'EXPORT_DIAGRAM_REQUEST';
+export const EXPORT_DIAGRAM_SUCCESS = 'EXPORT_DIAGRAM_SUCCESS';
+export const EXPORT_DIAGRAM_FAILURE = 'EXPORT_DIAGRAM_FAILURE';
 
 
 export function filterDatabases(name) {
@@ -56,6 +60,35 @@ export function saveDatabaseDiagram(diagramJSON) {
       dispatch({ type: SAVE_DIAGRAM_SUCCESS, fileName });
     } catch (error) {
       dispatch({ type: SAVE_DIAGRAM_FAILURE, error });
+    }
+  };
+}
+
+export function exportDatabaseDiagram(diagram, imageType) {
+  return async (dispatch, getState) => {
+    dispatch({ type: EXPORT_DIAGRAM_REQUEST });
+    try {
+      // fix - reapply css roles which html2canvas ignores for some reason
+      $('.link-tools, .marker-arrowheads', diagram).css({ display: 'none' });
+      $('.link, .connection', diagram).css({ fill: 'none' });
+
+      // html2canvas library only captures elements in window view
+      diagram.scrollIntoView();
+
+      const filters = [{ name: 'Images', extensions: [imageType] }];
+      const fileName = await FileHandler.showSaveDialog(filters);
+
+      // Create image
+      const canvas = await html2canvas(diagram, { background: '#fff' });
+      const image = await canvas.toDataURL(`image/${imageType}`);
+      const imageData = image.replace(/^data:image\/\w+;base64,/, "");
+      const buff = new Buffer(imageData, 'base64');
+
+      await FileHandler.saveFile(fileName, buff, 'binary');
+
+      dispatch({ type: EXPORT_DIAGRAM_SUCCESS });
+    } catch (error) {
+      dispatch({ type: EXPORT_DIAGRAM_FAILURE, error });
     }
   };
 }

--- a/src/renderer/actions/databases.js
+++ b/src/renderer/actions/databases.js
@@ -65,7 +65,7 @@ export function saveDatabaseDiagram(diagramJSON) {
 }
 
 export function exportDatabaseDiagram(diagram, imageType) {
-  return async (dispatch, getState) => {
+  return async (dispatch) => {
     dispatch({ type: EXPORT_DIAGRAM_REQUEST });
     try {
       // fix - reapply css roles which html2canvas ignores for some reason
@@ -81,7 +81,7 @@ export function exportDatabaseDiagram(diagram, imageType) {
       // Create image
       const canvas = await html2canvas(diagram, { background: '#fff' });
       const image = await canvas.toDataURL(`image/${imageType}`);
-      const imageData = image.replace(/^data:image\/\w+;base64,/, "");
+      const imageData = image.replace(/^data:image\/\w+;base64,/, '');
       const buff = new Buffer(imageData, 'base64');
 
       await FileHandler.saveFile(fileName, buff, 'binary');

--- a/src/renderer/components/database-diagram-modal.jsx
+++ b/src/renderer/components/database-diagram-modal.jsx
@@ -81,6 +81,17 @@ export default class DatabaseDiagramModal extends Component {
     addRelatedTables(relatedTables);
   }
 
+  onExportDatabaseDiagram(imageType) {
+    const { onExportDatabaseDiagram } = this.props;
+    const diagram = this.refs.databaseDiagram.refs.diagram;
+
+    // fix - reapply css roles which html2canvas ignores for some reason
+    $('.link-tools, .marker-arrowheads', diagram).css({ display: 'none' });
+    $('.link, .connection', diagram).css({ fill: 'none' });
+
+    onExportDatabaseDiagram(diagram, imageType);
+  }
+
   showDiagramIfNeeded(props) {
     if (this.isDataLoaded(props) || props.diagramJSON) {
       this.setState({ showDatabaseDiagram: true });
@@ -184,7 +195,7 @@ export default class DatabaseDiagramModal extends Component {
   }
 
   renderActionButtons() {
-    const { onSaveDatabaseDiagram, onExportDatabaseDiagram } = this.props;
+    const { onSaveDatabaseDiagram } = this.props;
 
     return (
       <div className="actions">
@@ -200,11 +211,11 @@ export default class DatabaseDiagramModal extends Component {
             <i className="dropdown icon"></i>
             <div className="menu">
               <div className="item"
-                onClick={() => onExportDatabaseDiagram(this.refs.databaseDiagram.refs.diagram, 'png')}>
+                onClick={() => this.onExportDatabaseDiagram('png')}>
                 PNG
               </div>
               <div className="item"
-                onClick={() => onExportDatabaseDiagram(this.refs.databaseDiagram.refs.diagram, 'jpeg')}>
+                onClick={() => this.onExportDatabaseDiagram('jpeg')}>
                 JPEG
               </div>
             </div>

--- a/src/renderer/components/database-diagram-modal.jsx
+++ b/src/renderer/components/database-diagram-modal.jsx
@@ -206,9 +206,9 @@ export default class DatabaseDiagramModal extends Component {
             Save
           </div>
           <div className="or"></div>
-          <div className="ui small button simple dropdown">
+          <div className="ui small right labeled icon button simple upward dropdown">
             Export to
-            <i className="dropdown icon"></i>
+            <i className="caret up icon"></i>
             <div className="menu">
               <div className="item"
                 onClick={() => this.onExportDatabaseDiagram('png')}>

--- a/src/renderer/components/database-diagram-modal.jsx
+++ b/src/renderer/components/database-diagram-modal.jsx
@@ -16,6 +16,7 @@ export default class DatabaseDiagramModal extends Component {
     columnsByTable: PropTypes.object,
     tableKeys: PropTypes.object,
     diagramJSON: PropTypes.string,
+    isSaving: PropTypes.bool,
     onGenerateDatabaseDiagram: PropTypes.func.isRequired,
     addRelatedTables: PropTypes.func.isRequired,
     onSaveDatabaseDiagram: PropTypes.func.isRequired,
@@ -166,6 +167,7 @@ export default class DatabaseDiagramModal extends Component {
       columnsByTable,
       tableKeys,
       diagramJSON,
+      isSaving,
       onAddRelatedTables,
     } = this.props;
 

--- a/src/renderer/components/database-diagram-modal.jsx
+++ b/src/renderer/components/database-diagram-modal.jsx
@@ -19,6 +19,7 @@ export default class DatabaseDiagramModal extends Component {
     onGenerateDatabaseDiagram: PropTypes.func.isRequired,
     addRelatedTables: PropTypes.func.isRequired,
     onSaveDatabaseDiagram: PropTypes.func.isRequired,
+    onExportDatabaseDiagram: PropTypes.func.isRequired,
     onOpenDatabaseDiagram: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired,
   }
@@ -175,19 +176,37 @@ export default class DatabaseDiagramModal extends Component {
         columnsByTable={columnsByTable}
         tableKeys={tableKeys}
         diagramJSON={diagramJSON}
+        isSaving={isSaving}
         addRelatedTables={::this.onAddRelatedTables} />
     );
   }
 
   renderActionButtons() {
-    const { onSaveDatabaseDiagram } = this.props;
+    const { onSaveDatabaseDiagram, onExportDatabaseDiagram } = this.props;
 
     return (
       <div className="actions">
-        <div className="ui small positive button"
-          tabIndex="0"
-          onClick={() => onSaveDatabaseDiagram(this.refs.databaseDiagram.graph.toJSON())}>
-          Save
+        <div className="ui buttons">
+          <div className="ui small positive button"
+            tabIndex="0"
+            onClick={() => onSaveDatabaseDiagram(this.refs.databaseDiagram.graph.toJSON())}>
+            Save
+          </div>
+          <div className="or"></div>
+          <div className="ui small button simple dropdown">
+            Export to
+            <i className="dropdown icon"></i>
+            <div className="menu">
+              <div className="item"
+                onClick={() => onExportDatabaseDiagram(this.refs.databaseDiagram.refs.diagram, 'png')}>
+                PNG
+              </div>
+              <div className="item"
+                onClick={() => onExportDatabaseDiagram(this.refs.databaseDiagram.refs.diagram, 'jpeg')}>
+                JPEG
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     );

--- a/src/renderer/components/database-diagram.css
+++ b/src/renderer/components/database-diagram.css
@@ -34,3 +34,7 @@
 .marker-arrowheads {
   display: none
 }
+
+.ui.simple.upward.dropdown > .menu {
+  top: auto !important;
+}

--- a/src/renderer/components/database-diagram.jsx
+++ b/src/renderer/components/database-diagram.jsx
@@ -13,6 +13,7 @@ export default class DatabaseDiagram extends Component {
     columnsByTable: PropTypes.object,
     tableKeys: PropTypes.object,
     diagramJSON: PropTypes.string,
+    isSaving: PropTypes.bool,
     addRelatedTables: PropTypes.func.isRequired,
   }
 
@@ -168,6 +169,13 @@ export default class DatabaseDiagram extends Component {
     });
   }
 
+  shouldDisableDiagram() {
+    const { isSaving } = this.props;
+    return isSaving
+      ? { pointerEvents: 'none' }
+      : { pointerEvents: 'auto' };
+  }
+
   onTableRightClick(table) {
     const { tableKeys, addRelatedTables } = this.props;
     const relatedTables = tableKeys[table].map(k => k.referencedTable).filter(rt => rt !== null);
@@ -179,6 +187,6 @@ export default class DatabaseDiagram extends Component {
       return <div className="ui negative message" style={{textAlign: 'center'}}>{this.state.error}</div>;
     }
 
-    return <div ref="diagram"></div>;
+    return <div ref="diagram" style={this.shouldDisableDiagram()}></div>;
   }
 }

--- a/src/renderer/containers/query-browser.jsx
+++ b/src/renderer/containers/query-browser.jsx
@@ -317,6 +317,7 @@ class QueryBrowserContainer extends Component {
         columnsByTable={columns.columnsByTable[selectedDB]}
         tableKeys={keys.keysByTable[selectedDB]}
         diagramJSON={databases.diagramJSON}
+        isSaving={databases.isSaving}
         onGenerateDatabaseDiagram={::this.onGenerateDatabaseDiagram}
         addRelatedTables={::this.onAddRelatedTables}
         onSaveDatabaseDiagram={::this.onSaveDatabaseDiagram}

--- a/src/renderer/containers/query-browser.jsx
+++ b/src/renderer/containers/query-browser.jsx
@@ -209,6 +209,10 @@ class QueryBrowserContainer extends Component {
     this.props.dispatch(DbAction.saveDatabaseDiagram(diagram));
   }
 
+  onExportDatabaseDiagram(diagram, imageType) {
+    this.props.dispatch(DbAction.exportDatabaseDiagram(diagram, imageType));
+  }
+
   onOpenDatabaseDiagram() {
     this.props.dispatch(DbAction.openDatabaseDiagram());
   }
@@ -316,6 +320,7 @@ class QueryBrowserContainer extends Component {
         onGenerateDatabaseDiagram={::this.onGenerateDatabaseDiagram}
         addRelatedTables={::this.onAddRelatedTables}
         onSaveDatabaseDiagram={::this.onSaveDatabaseDiagram}
+        onExportDatabaseDiagram={::this.onExportDatabaseDiagram}
         onOpenDatabaseDiagram={::this.onOpenDatabaseDiagram}
         onClose={::this.onCloseDiagramModal} />
     );

--- a/src/renderer/reducers/databases.js
+++ b/src/renderer/reducers/databases.js
@@ -79,6 +79,7 @@ export default function (state = INITIAL_STATE, action) {
     };
   }
   case types.SAVE_DIAGRAM_FAILURE:
+  case types.EXPORT_DIAGRAM_FAILURE:
   case types.OPEN_DIAGRAM_FAILURE: {
     return {
       ...state,

--- a/src/renderer/reducers/databases.js
+++ b/src/renderer/reducers/databases.js
@@ -11,6 +11,7 @@ const INITIAL_STATE = {
   diagramDatabase: null,
   fileName: null,
   diagramJSON: null,
+  isSaving: false,
 };
 
 
@@ -65,10 +66,19 @@ export default function (state = INITIAL_STATE, action) {
       fileName: null,
     };
   }
-  case types.SAVE_DIAGRAM_SUCCESS: {
+  case types.SAVE_DIAGRAM_REQUEST:
+  case types.EXPORT_DIAGRAM_REQUEST: {
+    return {
+      ...state,
+      isSaving: true,
+    };
+  }
+  case types.SAVE_DIAGRAM_SUCCESS:
+  case types.EXPORT_DIAGRAM_SUCCESS: {
     return {
       ...state,
       fileName: action.fileName,
+      isSaving: false,
     };
   }
   case types.OPEN_DIAGRAM_SUCCESS: {
@@ -84,6 +94,7 @@ export default function (state = INITIAL_STATE, action) {
     return {
       ...state,
       error: action.error,
+      isSaving: false,
     };
   }
   case queryTypes.EXECUTE_QUERY_SUCCESS: {

--- a/src/renderer/reducers/tables.js
+++ b/src/renderer/reducers/tables.js
@@ -68,7 +68,7 @@ export default function (state = INITIAL_STATE, action) {
     return {
       ...state,
       selectedTablesForDiagram: null,
-    }
+    };
   }
   default : return state;
   }

--- a/src/renderer/utils/file-handler.js
+++ b/src/renderer/utils/file-handler.js
@@ -17,9 +17,9 @@ export function showSaveDialog(filters) {
 }
 
 
-export function saveFile(fileName, data) {
+export function saveFile(fileName, data, encoding = 'utf8') {
   return new Promise((resolve, reject) => {
-    fs.writeFile(fileName, data, 'utf8', (err) => {
+    fs.writeFile(fileName, data, encoding, (err) => {
       if (err) { return reject(err); }
       resolve();
     });


### PR DESCRIPTION
Title says it all, PR implements feature enabling user to export diagram to `.png` and `.jpeg` format. :tada:

Next to save button, there's  simple dropdown button which offers user option to export diagram to one of the formats.

Although I thought it will be much simpler to export to SVG then png/jpeg, it turned out to be quite opposite. Reason is following. When I was creating diagram I followed JointJS [doc and tutorials](http://jointjs.com/tutorial/html-elements) on offical page. There is actually tutorial and example on how to build your custom elements containing plain HTML. Now it turns out, you can not simply do `svgImage = paper.svg` ,because `svg` JointJS spits out does not contain custom HTML elements. JointJS places them just above real basic `svg` elements (which I knew before but never thought it might be a problem :) ). So to enable export to `svg` it's required to rewrite diagram components to `svg` markup. At least I don't see any way around. After some searching around I found this [suggesting the same](https://groups.google.com/forum/#!msg/jointjs/QCeZ3ucyTNM/wcLkpnsOQ7MJ). Also there might be problem with loading external css. I'll try to catch up on this in a couple of weeks or so when I'll have more time. For now lets stick to 'image' formats.

Regarding the export to image formats, I used [html2canvas](https://www.npmjs.com/package/html2canvas) library which basically captures reconstructs 'screenshot' of a specified element. Quite neat tool actually :)

@maxcnunes Only one thing, there's a following `webpack` warning showing up after importing `html2canvas` :

![webpack_warning_html2canvas](https://cloud.githubusercontent.com/assets/8470710/16066006/01a5395a-32b0-11e6-8bb2-9c7b5b21c8bc.png)

I guess there are two possible solutions - ignore it or fetch source directly from github? No?
