### PR TITLE
Doesn't show scrollbar on header any more, fix height for one or multiples rows

### DIFF
--- a/src/renderer/components/query-result-table.jsx
+++ b/src/renderer/components/query-result-table.jsx
@@ -234,13 +234,15 @@ export default class QueryResultTable extends Component {
     const { rowCount, fields } = this.props;
     const { tableWidth, tableHeight } = this.state;
 
+    let fixedHeightRow = (rowCount > 1) ? rowCount * 32: 48;
+
     return (
       <Grid
         className="grid-body"
         ref={(ref) => { this.rowsGrid = ref; }}
         cellRenderer={::this.renderCell}
         width={tableWidth}
-        height={Math.min((tableHeight - 62), (rowCount * 32))}
+        height={Math.min((tableHeight - 62), fixedHeightRow)}
         rowHeight={28}
         onScroll={onScroll}
         rowCount={rowCount}
@@ -254,7 +256,9 @@ export default class QueryResultTable extends Component {
 
   renderTableHeader(scrollLeft) {
     const { fields } = this.props;
-    const { tableWidth } = this.state;
+    const { tableWidth, tableHeight } = this.state;
+
+    console.log(this);
 
     if (!fields.length) {
       return null;
@@ -270,7 +274,8 @@ export default class QueryResultTable extends Component {
         className="grid-header-row"
         rowHeight={30}
         rowCount={1}
-        width={tableWidth - scrollbarSize()}
+        height={30}
+        width={tableWidth}
         scrollLeft={scrollLeft} />
     );
   }

--- a/src/renderer/components/query-result-table.jsx
+++ b/src/renderer/components/query-result-table.jsx
@@ -1,7 +1,6 @@
 import { debounce } from 'lodash';
 import React, { Component, PropTypes } from 'react';
 import { Grid, ScrollSync } from 'react-virtualized';
-import scrollbarSize from 'dom-helpers/util/scrollbarSize';
 import Draggable from 'react-draggable';
 
 import TableCell from './query-result-table-cell.jsx';

--- a/src/renderer/components/query-result-table.jsx
+++ b/src/renderer/components/query-result-table.jsx
@@ -261,7 +261,7 @@ export default class QueryResultTable extends Component {
 
   renderTableHeader(scrollLeft) {
     const { fields } = this.props;
-    const { tableWidth, tableHeight } = this.state;
+    const { tableWidth } = this.state;
 
     if (!fields.length) {
       return null;

--- a/src/renderer/components/query-result-table.jsx
+++ b/src/renderer/components/query-result-table.jsx
@@ -238,9 +238,6 @@ export default class QueryResultTable extends Component {
     const offsetHeight = scrollBarSize + 9;
     const fixedHeightRow = (rowCount > 1) ? (rowCount * 32) - offsetHeight : 44;
 
-    console.log("fixed: "+fixedHeightRow);
-    console.log("tableHeight: "+(tableHeight-62));
-
     return (
       <Grid
         className="grid-body"

--- a/src/renderer/components/query-result-table.jsx
+++ b/src/renderer/components/query-result-table.jsx
@@ -234,7 +234,12 @@ export default class QueryResultTable extends Component {
     const { rowCount, fields } = this.props;
     const { tableWidth, tableHeight } = this.state;
 
-    let fixedHeightRow = (rowCount > 1) ? rowCount * 32: 48;
+    const scrollBarSize = 15;
+    const offsetHeight = scrollBarSize + 9;
+    const fixedHeightRow = (rowCount > 1) ? (rowCount * 32) - offsetHeight : 44;
+
+    console.log("fixed: "+fixedHeightRow);
+    console.log("tableHeight: "+(tableHeight-62));
 
     return (
       <Grid
@@ -258,8 +263,6 @@ export default class QueryResultTable extends Component {
     const { fields } = this.props;
     const { tableWidth, tableHeight } = this.state;
 
-    console.log(this);
-
     if (!fields.length) {
       return null;
     }
@@ -274,7 +277,6 @@ export default class QueryResultTable extends Component {
         className="grid-header-row"
         rowHeight={30}
         rowCount={1}
-        height={30}
         width={tableWidth}
         scrollLeft={scrollLeft} />
     );

--- a/src/renderer/components/query-result-table.scss
+++ b/src/renderer/components/query-result-table.scss
@@ -47,7 +47,7 @@
 }
 
 .Grid.grid-header-row .Grid__cell {
-  overflow: visible;
+  //overflow: visible;
   font-weight: bold;
   padding-left: 10px;
   padding-right: 10px;
@@ -65,7 +65,7 @@
 }
 
 .Grid.grid-header-row {
-  overflow: hidden;
+  overflow: hidden !important;
   background: #f9fafb;
   border: 1px solid rgba(34,36,38,.1);
   border-right: none;

--- a/src/renderer/components/query-result-table.scss
+++ b/src/renderer/components/query-result-table.scss
@@ -47,7 +47,7 @@
 }
 
 .Grid.grid-header-row .Grid__cell {
-  //overflow: visible;
+  overflow: visible;
   font-weight: bold;
   padding-left: 10px;
   padding-right: 10px;


### PR DESCRIPTION
Changes:
- Fix height when result only has one row and the way to calculate multiple row height.
- Remove scrollbar from header table

Modified files:

- src/renderer/components/query-result-table.jsx
- src/renderer/components/query-result-table.scss

![captura de pantalla de 2016-07-07 13-31-58](https://cloud.githubusercontent.com/assets/1167738/16652028/fa633a62-4447-11e6-91a5-fb395409b414.png)
![captura de pantalla de 2016-07-07 13-31-21](https://cloud.githubusercontent.com/assets/1167738/16652030/fc7ca05e-4447-11e6-80a8-70196346138c.png)
