### PR TITLE
fix: Fix warning about null input and fix style

### DIFF
--- a/src/renderer/components/server-modal-form.jsx
+++ b/src/renderer/components/server-modal-form.jsx
@@ -277,7 +277,7 @@ export default class ServerModalForm extends Component {
                       name="socketPath"
                       maxLength="250"
                       placeholder="Unix socket path"
-                      value={this.state.socketPath}
+                      value={this.state.socketPath || ''}
                       onChange={::this.handleChange}
                       disabled={(
                         this.state.host ||
@@ -413,7 +413,7 @@ export default class ServerModalForm extends Component {
                           tabIndex="0"
                           className="hidden"
                           disabled={(!isSSHChecked || ssh.password)}
-                          defaultChecked={this.state.ssh && this.state.ssh.privateKeyWithPassphrase} />
+                          defaultChecked={ssh && ssh.privateKeyWithPassphrase} />
                         <label>Passphrase</label>
                       </div>
                     </div>


### PR DESCRIPTION
When you opened the server modal you got an error about an input field that is null and shouldn't...

here is a fix about it, and in the meantime i fixed a linting / consistency issue by replacing this.state.ssh to previously defined ssh.