### PR TITLE
fix: fix closing connection for a test connection

### DIFF
--- a/src/renderer/actions/connections.js
+++ b/src/renderer/actions/connections.js
@@ -128,18 +128,18 @@ export function reconnect (id, database) {
 export function test (server) {
   return async (dispatch) => {
     dispatch({ type: TEST_CONNECTION_REQUEST, server });
-    let testServerSession;
+    let dbClient;
     try {
-      testServerSession = sqlectron.db.createServer(server);
-      const dbClient = testServerSession.createConnection(server.database);
+      const testServerSession = sqlectron.db.createServer(server);
+      dbClient = testServerSession.createConnection(server.database);
 
       await dbClient.connect(server, server.database);
       dispatch({ type: TEST_CONNECTION_SUCCESS, server });
     } catch (error) {
       dispatch({ type: TEST_CONNECTION_FAILURE, server, error });
     } finally {
-      if (testServerSession) {
-        testServerSession.disconnect();
+      if (dbClient) {
+        dbClient.disconnect();
       }
     }
   };


### PR DESCRIPTION
If you tried to test a connection, we tried to disconnect it using a
not existing method. here is an attempt to fix this
<img width="1042" alt="capture d ecran 2016-09-18 a 16 39 21" src="https://cloud.githubusercontent.com/assets/177003/18616566/8142dfba-7dbe-11e6-9044-7b93365b980c.png">
