### PR TITLE
feat: Add visual distinction to indicate if there are items below

### DIFF
--- a/src/renderer/components/database-list-item-metadata.jsx
+++ b/src/renderer/components/database-list-item-metadata.jsx
@@ -39,15 +39,21 @@ export default class DbMetadataList extends Component {
   }
 
   renderHeader() {
+    const {
+      items,
+    } = this.props;
     const title = this.state.collapsed ? 'Expand' : 'Collapse';
     const cssClass = this.state.collapsed ? 'right' : 'down';
-
+    const cssStyle = { ...STYLE.header };
+    if (!items || !items.length) {
+      cssStyle.color = 'lightgray';
+    }
     return (
       <span
         title={title}
         className="header clickable"
         onClick={::this.toggleCollapse}
-        style={STYLE.header}>
+        style={cssStyle}>
         <i className={`${cssClass} triangle icon`}></i>
         {this.props.title}
       </span>

--- a/src/renderer/components/table-submenu.jsx
+++ b/src/renderer/components/table-submenu.jsx
@@ -33,15 +33,20 @@ export default class TableSubmenu extends Component {
   }
 
   renderSubMenuHeader() {
+    const { itemsByTable, table } = this.props;
+
     const title = this.state.collapsed ? 'Expand' : 'Collapse';
     const cssClass = this.state.collapsed ? 'right' : 'down';
-
+    const cssStyle = { ...STYLE.header };
+    if (!itemsByTable || !itemsByTable[table] || itemsByTable[table].length) {
+      cssStyle.color = 'lightgray';
+    }
     return (
       <span
         title={title}
         className="header clickable"
         onClick={::this.toggleCollapse}
-        style={STYLE.header}>
+        style={cssStyle}>
         <i className={`${cssClass} triangle icon`}></i>
         {this.props.title}
       </span>


### PR DESCRIPTION
I was frustrated while browsing the database, 
stumbling upon many "No result found" after clicking the view submenu to open it.

So i thought about having some kind of visual distinction.. here is my take

Before:
<img width="210" alt="capture d ecran 2016-09-19 a 23 19 27" src="https://cloud.githubusercontent.com/assets/177003/18728063/d5fe96c2-804b-11e6-9215-d6470d08af31.png">

After:
<img width="211" alt="capture d ecran 2016-09-21 a 22 31 53" src="https://cloud.githubusercontent.com/assets/177003/18728080/e0f078a2-804b-11e6-99bc-ca506c527b8f.png">


