### PR TITLE
improve: Change disconnect icon to poweroff

### DIFF
--- a/src/renderer/components/header.jsx
+++ b/src/renderer/components/header.jsx
@@ -56,7 +56,7 @@ const Header = ({ items, onCloseConnectionClick, onReConnectionClick }) => {
             <button className="ui icon button"
               title="Close connection"
               onClick={onCloseConnectionClick}>
-              <i className="ban icon"></i>
+              <i className="power icon"></i>
             </button>
           </div>
         </div>


### PR DESCRIPTION
Hi, 

Here is a litte proposition with a little PR, 
i was really intrigued  by the choice of the "disconnect" icon, as semantic ui says, it was the "Ban" icon... which is not really what we want...

i tried the "sign-out" which is what feels more natural , but the look does not right to me : 
<img width="133" alt="capture d ecran 2016-09-23 a 21 40 27" src="https://cloud.githubusercontent.com/assets/177003/18799144/61e6e762-81d6-11e6-92e7-945f0ea7f1b5.png">

so i tried the universally understood "power off", and seems better, 
what do you think ?

<img width="157" alt="capture d ecran 2016-09-23 a 21 36 21" src="https://cloud.githubusercontent.com/assets/177003/18799164/7a11fd7c-81d6-11e6-8ee8-85e1376e6b87.png">


Another question i had was about the reconnect icon; aside from the icon that don't feel really obvious to me either, isn't it possible to remove it ? or maybe put it only when we are disconnected or smth ?
what do you guys think?

