### PR TITLE
ux: hide tab mover (left/right) when the tab list fit on screen

### DIFF
--- a/src/renderer/containers/query-browser.jsx
+++ b/src/renderer/containers/query-browser.jsx
@@ -407,17 +407,20 @@ class QueryBrowserContainer extends Component {
       this.tabListTotalWidthChildren - Math.abs(this.state.tabNavPosition) <= this.tabListTotalWidth
     );
     const selectedIndex = queries.queryIds.indexOf(queries.currentQueryId);
+    const isTabsFitOnScreen = this.tabListTotalWidthChildren >= this.tabListTotalWidth;
     return (
       <Tabs onSelect={::this.handleSelectTab} selectedIndex={selectedIndex}>
         <div id="tabs-nav-wrapper" className="ui pointing secondary menu">
-          <button className="ui icon button"
-            disabled={this.state.tabNavPosition === 0}
-            onClick={() => {
-              const position = this.state.tabNavPosition + 100;
-              this.setState({ tabNavPosition: position > 0 ? 0 : position });
-            }}>
-            <i className="left chevron icon"></i>
-          </button>
+          {isTabsFitOnScreen &&
+            <button className="ui icon button"
+              disabled={this.state.tabNavPosition === 0}
+              onClick={() => {
+                const position = this.state.tabNavPosition + 100;
+                this.setState({ tabNavPosition: position > 0 ? 0 : position });
+              }}>
+              <i className="left chevron icon"></i>
+            </button>
+          }
           <div className="tabs-container">
             <TabList
               ref="tabList"
@@ -425,14 +428,16 @@ class QueryBrowserContainer extends Component {
               {menu}
             </TabList>
           </div>
-          <button className="ui icon button"
-            disabled={this.tabListTotalWidthChildren < this.tabListTotalWidth || isOnMaxPosition}
-            onClick={() => {
-              const position = this.state.tabNavPosition - 100;
-              this.setState({ tabNavPosition: position });
-            }}>
-            <i className="right chevron icon"></i>
-          </button>
+          {isTabsFitOnScreen &&
+            <button className="ui icon button"
+              disabled={this.tabListTotalWidthChildren < this.tabListTotalWidth || isOnMaxPosition}
+              onClick={() => {
+                const position = this.state.tabNavPosition - 100;
+                this.setState({ tabNavPosition: position });
+              }}>
+              <i className="right chevron icon"></i>
+            </button>
+          }
         </div>
         {panels}
       </Tabs>


### PR DESCRIPTION
@maxcnunes  refactor the tab list that work really better now, 
but i think it "clutter" the screen a bit while you don't have many tab open...

here is a propostion about hidding arrow if the tab list fit in the screen
<img width="872" alt="capture d ecran 2016-10-03 a 23 04 39" src="https://cloud.githubusercontent.com/assets/177003/19054158/4e9e2518-89be-11e6-8c3a-7421b6e1a85a.png">

<img width="833" alt="capture d ecran 2016-10-03 a 23 04 51" src="https://cloud.githubusercontent.com/assets/177003/19054159/4e9e27de-89be-11e6-8c0c-d4649befd2ef.png">


what do you think?

