### PR TITLE
feat: add 'via' in the server list to make distinction with ssh

### DIFF
--- a/src/renderer/components/server-list-item.jsx
+++ b/src/renderer/components/server-list-item.jsx
@@ -29,8 +29,9 @@ const ServerListItem = ({ server, onConnectClick, onEditClick }) => (
       <div className="header">
         {server.name}
       </div>
-      <div className="meta" style={{ lineHeight: '1.5em', marginTop: '5px' }}>
+      <div className="meta" style={{ lineHeight: '1.5em', marginTop: '5px', marginLeft: '45px' }}>
         {server.host ? `${server.host}:${server.port}` : server.socketPath}
+        {server.ssh && (<div>via {server.ssh.host}</div>)}
       </div>
     </div>
     <div className="ui bottom attached button"


### PR DESCRIPTION
When connecting to 2 db one in local one via ssh, 
you have no ways to distinct them.

Here is an attempt at fixing that

<img width="463" alt="capture d ecran 2016-10-03 a 23 53 48" src="https://cloud.githubusercontent.com/assets/177003/19055530/a806b0d8-89c4-11e6-89d0-ab89cfb2b165.png">
