### PR TITLE
feat: allow press 'enter' to submit promp modal like passphrase and all

### DIFF
--- a/src/renderer/components/prompt-modal.jsx
+++ b/src/renderer/components/prompt-modal.jsx
@@ -29,6 +29,12 @@ export default class PromptModal extends Component {
     $(this.refs.promptModal).modal('hide');
   }
 
+  handleKeyPress(event) {
+    if (event.key === 'Enter') {
+      this.props.onOKClick(this.refs.text.value);
+    }
+  }
+
   render() {
     const { title, message, type } = this.props;
 
@@ -40,7 +46,7 @@ export default class PromptModal extends Component {
         <div className="content">
           {message}
           <div className="ui fluid icon input">
-            <input ref="text" type={type} />
+            <input ref="text" type={type} onKeyPress={::this.handleKeyPress} />
           </div>
         </div>
         <div className="actions">


### PR DESCRIPTION
it's really annoying to have to type the passphrase, then grab the mouse, and click "ok" instead of just pressing "enter" as usual.
