### PR TITLE
feat: change double click on the DB header to simple click

### DIFF
--- a/src/renderer/components/database-list-item.jsx
+++ b/src/renderer/components/database-list-item.jsx
@@ -74,7 +74,7 @@ export default class DatabaseListItem extends Component {
     this.setState({ filter: value });
   }
 
-  onHeaderDoubleClick(database) {
+  onHeaderClick(database) {
     if (!this.isMetadataLoaded()) {
       this.props.onSelectDatabase(database);
       return;
@@ -112,12 +112,12 @@ export default class DatabaseListItem extends Component {
     return (
       <span
         className="header"
-        onDoubleClick={() => this.onHeaderDoubleClick(database)}
+        onClick={() => this.onHeaderClick(database)}
         onContextMenu={::this.onContextMenu}
         style={STYLE.database}>
         <i className={`${collapseCssClass} triangle icon`}
           style={{ cursor: 'pointer' }}
-          onClick={() => this.onHeaderDoubleClick(database)}></i>
+          onClick={() => this.onHeaderClick(database)}></i>
         <i className="database icon"></i>
         {database.name}
       </span>


### PR DESCRIPTION
On the left sidebar, 
You have to Double click on the database Header name or reach the little arrow and simple click on it.
it feels unnatural for me, and the comportment is different in lower levels (tables, view, ...)

here is a proposition to make the thing work with a simple click.
