### PR TITLE
Server can be saved without a password or a user

### DIFF
--- a/src/renderer/components/server-modal-form.jsx
+++ b/src/renderer/components/server-modal-form.jsx
@@ -129,8 +129,8 @@ export default class ServerModalForm extends Component {
       host: state.host && state.host.length ? state.host : null,
       port: state.port || state.defaultPort,
       socketPath: state.socketPath && state.socketPath.length ? state.socketPath : null,
-      user: state.user,
-      password: state.password,
+      user: state.user || null,
+      password: state.password || null,
       database: state.database,
     };
     if (!this.state.ssh) { return server; }


### PR DESCRIPTION
#253 

If you tried to create a new server and never touched user/password fields it would save fine, but if you typed something in the user/password fields and then erased it, the GUI didn't allow you to save the server anymore.