### PR TITLE
Basic Schema support

### DIFF
--- a/src/renderer/actions/columns.js
+++ b/src/renderer/actions/columns.js
@@ -6,10 +6,10 @@ export const FETCH_COLUMNS_SUCCESS = 'FETCH_COLUMNS_SUCCESS';
 export const FETCH_COLUMNS_FAILURE = 'FETCH_COLUMNS_FAILURE';
 
 
-export function fetchTableColumnsIfNeeded (database, table) {
+export function fetchTableColumnsIfNeeded (database, table, schema) {
   return (dispatch, getState) => {
-    if (shouldFetchTableColumns(getState(), database, table)) {
-      dispatch(fetchTableColumns(database, table));
+    if (shouldFetchTableColumns(getState(), database, table, schema)) {
+      dispatch(fetchTableColumns(database, table, schema));
     }
   };
 }
@@ -25,12 +25,12 @@ function shouldFetchTableColumns (state, database, table) {
 }
 
 
-function fetchTableColumns (database, table) {
+function fetchTableColumns (database, table, schema) {
   return async dispatch => {
     dispatch({ type: FETCH_COLUMNS_REQUEST, database, table });
     try {
       const dbConn = getDBConnByName(database);
-      const columns = await dbConn.listTableColumns(table);
+      const columns = await dbConn.listTableColumns(table, schema);
       dispatch({ type: FETCH_COLUMNS_SUCCESS, database, table, columns });
     } catch (error) {
       dispatch({ type: FETCH_COLUMNS_FAILURE, error });

--- a/src/renderer/actions/keys.js
+++ b/src/renderer/actions/keys.js
@@ -6,10 +6,10 @@ export const FETCH_KEYS_SUCCESS = 'FETCH_KEYS_SUCCESS';
 export const FETCH_KEYS_FAILURE = 'FETCH_KEYS_FAILURE';
 
 
-export function fetchTableKeysIfNeeded (database, table) {
+export function fetchTableKeysIfNeeded (database, table, schema) {
   return (dispatch, getState) => {
     if (shouldFetchTableKeys(getState(), database, table)) {
-      dispatch(fetchTableKeys(database, table));
+      dispatch(fetchTableKeys(database, table, schema));
     }
   };
 }
@@ -25,12 +25,12 @@ function shouldFetchTableKeys (state, database, table) {
 }
 
 
-function fetchTableKeys (database, table) {
+function fetchTableKeys (database, table, schema) {
   return async dispatch => {
     dispatch({ type: FETCH_KEYS_REQUEST, database, table });
     try {
       const dbConn = getDBConnByName(database);
-      const tableKeys = await dbConn.getTableKeys(table);
+      const tableKeys = await dbConn.getTableKeys(table, schema);
       dispatch({ type: FETCH_KEYS_SUCCESS, database, table, tableKeys });
     } catch (error) {
       dispatch({ type: FETCH_KEYS_FAILURE, error });

--- a/src/renderer/actions/queries.js
+++ b/src/renderer/actions/queries.js
@@ -53,11 +53,11 @@ export function executeQueryIfNeeded (query) {
 }
 
 
-export function executeDefaultSelectQueryIfNeeded (database, table) {
+export function executeDefaultSelectQueryIfNeeded (database, table, schema) {
   return async (dispatch, getState) => {
     const currentState = getState();
     const dbConn = getDBConnByName(database);
-    const queryDefaultSelect = await dbConn.getQuerySelectTop(table);
+    const queryDefaultSelect = await dbConn.getQuerySelectTop(table, schema);
 
     if (!shouldExecuteQuery(queryDefaultSelect, currentState)) {
       return;

--- a/src/renderer/actions/routines.js
+++ b/src/renderer/actions/routines.js
@@ -6,10 +6,10 @@ export const FETCH_ROUTINES_SUCCESS = 'FETCH_ROUTINES_SUCCESS';
 export const FETCH_ROUTINES_FAILURE = 'FETCH_ROUTINES_FAILURE';
 
 
-export function fetchRoutinesIfNeeded (database) {
+export function fetchRoutinesIfNeeded (database, schema) {
   return (dispatch, getState) => {
     if (shouldFetchRoutines(getState(), database)) {
-      dispatch(fetchRoutines(database));
+      dispatch(fetchRoutines(database, schema));
     }
   };
 }
@@ -23,12 +23,12 @@ function shouldFetchRoutines (state, database) {
   return routines.didInvalidate;
 }
 
-function fetchRoutines (database) {
+function fetchRoutines (database, schema) {
   return async (dispatch, getState) => {
     dispatch({ type: FETCH_ROUTINES_REQUEST, database });
     try {
       const dbConn = getCurrentDBConn(getState());
-      const routines = await dbConn.listRoutines();
+      const routines = await dbConn.listRoutines(schema);
       dispatch({ type: FETCH_ROUTINES_SUCCESS, database, routines });
     } catch (error) {
       dispatch({ type: FETCH_ROUTINES_FAILURE, error });

--- a/src/renderer/actions/schemas.js
+++ b/src/renderer/actions/schemas.js
@@ -1,0 +1,37 @@
+import { getCurrentDBConn } from './connections';
+
+
+export const FETCH_SCHEMAS_REQUEST = 'FETCH_SCHEMAS_REQUEST';
+export const FETCH_SCHEMAS_SUCCESS = 'FETCH_SCHEMAS_SUCCESS';
+export const FETCH_SCHEMAS_FAILURE = 'FETCH_SCHEMAS_FAILURE';
+
+export function fetchSchemasIfNeeded (database) {
+  return (dispatch, getState) => {
+    if (shouldFetchSchemas(getState(), database)) {
+      dispatch(fetchSchemas(database));
+    }
+  };
+}
+
+
+function shouldFetchSchemas (state, database) {
+  const schemas = state.schemas;
+  if (!schemas) return true;
+  if (schemas.isFetching) return false;
+  if (!schemas.itemsByDatabase[database]) return true;
+  return schemas.didInvalidate;
+}
+
+
+function fetchSchemas (database) {
+  return async (dispatch, getState) => {
+    dispatch({ type: FETCH_SCHEMAS_REQUEST, database });
+    try {
+      const dbConn = getCurrentDBConn(getState());
+      const schemas = await dbConn.listSchemas();
+      dispatch({ type: FETCH_SCHEMAS_SUCCESS, database, schemas });
+    } catch (error) {
+      dispatch({ type: FETCH_SCHEMAS_FAILURE, error });
+    }
+  };
+}

--- a/src/renderer/actions/sqlscripts.js
+++ b/src/renderer/actions/sqlscripts.js
@@ -7,11 +7,11 @@ export const GET_SCRIPT_SUCCESS = 'GET_SCRIPT_SUCCESS';
 export const GET_SCRIPT_FAILURE = 'GET_SCRIPT_FAILURE';
 
 
-export function getSQLScriptIfNeeded(database, item, actionType, objectType) {
+export function getSQLScriptIfNeeded(database, item, actionType, objectType, schema) {
   return (dispatch, getState) => {
     const state = getState();
     if (shouldFetchScript(state, database, item, actionType)) {
-      dispatch(getSQLScript(database, item, actionType, objectType));
+      dispatch(getSQLScript(database, item, actionType, objectType, schema));
       return;
     }
 
@@ -45,26 +45,26 @@ function getAlreadyFetchedScript (state, database, item, actionType) {
 }
 
 
-function getSQLScript (database, item, actionType, objectType) {
+function getSQLScript (database, item, actionType, objectType, schema) {
   return async (dispatch) => {
     dispatch({ type: GET_SCRIPT_REQUEST, database, item, actionType, objectType });
     try {
       const dbConn = getDBConnByName(database);
       let script;
       if (actionType === 'CREATE' && objectType === 'Table') {
-        [script] = await dbConn.getTableCreateScript(item);
+        [script] = await dbConn.getTableCreateScript(item, schema);
       } else if (actionType === 'CREATE' && objectType === 'View') {
-        [script] = await dbConn.getViewCreateScript(item);
+        [script] = await dbConn.getViewCreateScript(item, schema);
       } else if (actionType === 'CREATE') {
-        [script] = await dbConn.getRoutineCreateScript(item, objectType);
+        [script] = await dbConn.getRoutineCreateScript(item, objectType, schema);
       } else if (actionType === 'SELECT') {
-        script = await dbConn.getTableSelectScript(item);
+        script = await dbConn.getTableSelectScript(item, schema);
       } else if (actionType === 'INSERT') {
-        script = await dbConn.getTableInsertScript(item);
+        script = await dbConn.getTableInsertScript(item, schema);
       } else if (actionType === 'UPDATE') {
-        script = await dbConn.getTableUpdateScript(item);
+        script = await dbConn.getTableUpdateScript(item, schema);
       } else if (actionType === 'DELETE') {
-        script = await dbConn.getTableDeleteScript(item);
+        script = await dbConn.getTableDeleteScript(item, schema);
       }
       dispatch({ type: GET_SCRIPT_SUCCESS, database, item, script, actionType, objectType });
       dispatch(appendQuery(script));

--- a/src/renderer/actions/tables.js
+++ b/src/renderer/actions/tables.js
@@ -12,10 +12,10 @@ export function selectTablesForDiagram(tables) {
 }
 
 
-export function fetchTablesIfNeeded (database) {
+export function fetchTablesIfNeeded (database, schema) {
   return (dispatch, getState) => {
     if (shouldFetchTables(getState(), database)) {
-      dispatch(fetchTables(database));
+      dispatch(fetchTables(database, schema));
     }
   };
 }
@@ -30,12 +30,12 @@ function shouldFetchTables (state, database) {
 }
 
 
-function fetchTables (database) {
+function fetchTables (database, schema) {
   return async (dispatch, getState) => {
     dispatch({ type: FETCH_TABLES_REQUEST, database });
     try {
       const dbConn = getCurrentDBConn(getState());
-      const tables = await dbConn.listTables();
+      const tables = await dbConn.listTables(schema);
       dispatch({ type: FETCH_TABLES_SUCCESS, database, tables });
     } catch (error) {
       dispatch({ type: FETCH_TABLES_FAILURE, error });

--- a/src/renderer/actions/triggers.js
+++ b/src/renderer/actions/triggers.js
@@ -6,10 +6,10 @@ export const FETCH_TRIGGERS_SUCCESS = 'FETCH_TRIGGERS_SUCCESS';
 export const FETCH_TRIGGERS_FAILURE = 'FETCH_TRIGGERS_FAILURE';
 
 
-export function fetchTableTriggersIfNeeded (database, table) {
+export function fetchTableTriggersIfNeeded (database, table, schema) {
   return (dispatch, getState) => {
     if (shouldFetchTableTriggers(getState(), database, table)) {
-      dispatch(fetchTableTriggers(database, table));
+      dispatch(fetchTableTriggers(database, table, schema));
     }
   };
 }
@@ -25,12 +25,12 @@ function shouldFetchTableTriggers (state, database, table) {
 }
 
 
-function fetchTableTriggers (database, table) {
+function fetchTableTriggers (database, table, schema) {
   return async dispatch => {
     dispatch({ type: FETCH_TRIGGERS_REQUEST, database, table });
     try {
       const dbConn = getDBConnByName(database);
-      const triggers = await dbConn.listTableTriggers(table);
+      const triggers = await dbConn.listTableTriggers(table, schema);
       dispatch({ type: FETCH_TRIGGERS_SUCCESS, database, table, triggers });
     } catch (error) {
       dispatch({ type: FETCH_TRIGGERS_FAILURE, error });

--- a/src/renderer/actions/views.js
+++ b/src/renderer/actions/views.js
@@ -6,10 +6,10 @@ export const FETCH_VIEWS_SUCCESS = 'FETCH_VIEWS_SUCCESS';
 export const FETCH_VIEWS_FAILURE = 'FETCH_VIEWS_FAILURE';
 
 
-export function fetchViewsIfNeeded (database) {
+export function fetchViewsIfNeeded (database, schema) {
   return (dispatch, getState) => {
     if (shouldFetchViews(getState(), database)) {
-      dispatch(fetchViews(database));
+      dispatch(fetchViews(database, schema));
     }
   };
 }
@@ -22,12 +22,12 @@ function shouldFetchViews (state, database) {
   return views.didInvalidate;
 }
 
-function fetchViews (database) {
+function fetchViews (database, schema) {
   return async (dispatch, getState) => {
     dispatch({ type: FETCH_VIEWS_REQUEST, database });
     try {
       const dbConn = getCurrentDBConn(getState());
-      const views = await dbConn.listViews();
+      const views = await dbConn.listViews(schema);
       dispatch({ type: FETCH_VIEWS_SUCCESS, database, views });
     } catch (error) {
       dispatch({ type: FETCH_VIEWS_FAILURE, error });

--- a/src/renderer/components/query.jsx
+++ b/src/renderer/components/query.jsx
@@ -162,6 +162,7 @@ export default class Query extends Component {
   getQueryCompletions(props) {
     const {
       databases,
+      schemas,
       tables,
       columnsByTable,
       triggersByTable,
@@ -182,6 +183,7 @@ export default class Query extends Component {
 
     return [
       ...mapCompletionTypes(databases, 'database'),
+      ...mapCompletionTypes(schemas, 'schema'),
       ...mapCompletionTypes(tables, 'table'),
       ...mapCompletionTypes(columnsByTable, 'column'),
       ...mapCompletionTypes(triggersByTable, 'trigger'),

--- a/src/renderer/components/server-modal-form.jsx
+++ b/src/renderer/components/server-modal-form.jsx
@@ -132,6 +132,7 @@ export default class ServerModalForm extends Component {
       user: state.user || null,
       password: state.password || null,
       database: state.database,
+      schema: state.schema || null,
     };
     if (!this.state.ssh) { return server; }
 
@@ -333,6 +334,16 @@ export default class ServerModalForm extends Component {
                   maxLength="100"
                   placeholder="Database"
                   value={this.state.database || ''}
+                  onChange={::this.handleChange} />
+              </div>
+              <div className={`six wide field ${this.highlightError('schema')}`}>
+                <label>Schema</label>
+                <input type="text"
+                  name="schema"
+                  maxLength="100"
+                  placeholder="Schema"
+                  disabled={this.isFeatureDisabled('server:schema')}
+                  value={this.state.schema || ''}
                   onChange={::this.handleChange} />
               </div>
             </div>

--- a/src/renderer/containers/query-browser.jsx
+++ b/src/renderer/containers/query-browser.jsx
@@ -10,6 +10,7 @@ import * as ConnActions from '../actions/connections.js';
 import * as QueryActions from '../actions/queries';
 import * as DbAction from '../actions/databases';
 import { fetchTablesIfNeeded, selectTablesForDiagram } from '../actions/tables';
+import { fetchSchemasIfNeeded } from '../actions/schemas';
 import { fetchTableColumnsIfNeeded } from '../actions/columns';
 import { fetchTableTriggersIfNeeded } from '../actions/triggers';
 import { fetchViewsIfNeeded } from '../actions/views';
@@ -61,6 +62,7 @@ class QueryBrowserContainer extends Component {
     connections: PropTypes.object.isRequired,
     status: PropTypes.string.isRequired,
     databases: PropTypes.object.isRequired,
+    schemas: PropTypes.object.isRequired,
     tables: PropTypes.object.isRequired,
     columns: PropTypes.object.isRequired,
     triggers: PropTypes.object.isRequired,
@@ -111,6 +113,7 @@ class QueryBrowserContainer extends Component {
 
     dispatch(DbAction.fetchDatabasesIfNeeded());
     dispatch(fetchTablesIfNeeded(lastConnectedDB));
+    dispatch(fetchSchemasIfNeeded(lastConnectedDB));
     dispatch(fetchViewsIfNeeded(lastConnectedDB));
     dispatch(fetchRoutinesIfNeeded(lastConnectedDB));
 
@@ -358,6 +361,7 @@ class QueryBrowserContainer extends Component {
       connections,
       queries,
       databases,
+      schemas,
       tables,
       columns,
       triggers,
@@ -436,6 +440,7 @@ class QueryBrowserContainer extends Component {
             enabledLiveAutoComplete={queries.enabledLiveAutoComplete}
             database={currentDB}
             databases={databases.items}
+            schemas={schemas.itemsByDatabase[query.database]}
             tables={tables.itemsByDatabase[query.database]}
             columnsByTable={columns.columnsByTable[query.database]}
             triggersByTable={triggers.triggersByTable[query.database]}
@@ -501,6 +506,7 @@ class QueryBrowserContainer extends Component {
       status,
       connections,
       databases,
+      schemas,
       tables,
       columns,
       triggers,
@@ -567,6 +573,7 @@ class QueryBrowserContainer extends Component {
                   client={connections.server.client}
                   databases={filteredDatabases}
                   isFetching={databases.isFetching}
+                  schemasByDatabase={schemas.itemsByDatabase}
                   tablesByDatabase={tables.itemsByDatabase}
                   columnsByTable={columns.columnsByTable}
                   triggersByTable={triggers.triggersByTable}
@@ -600,6 +607,7 @@ function mapStateToProps (state) {
   const {
     connections,
     databases,
+    schemas,
     tables,
     columns,
     triggers,
@@ -614,6 +622,7 @@ function mapStateToProps (state) {
   return {
     connections,
     databases,
+    schemas,
     tables,
     columns,
     triggers,

--- a/src/renderer/containers/query-browser.jsx
+++ b/src/renderer/containers/query-browser.jsx
@@ -110,12 +110,13 @@ class QueryBrowserContainer extends Component {
     }
 
     const lastConnectedDB = connections.databases[connections.databases.length - 1];
+    const schema = connections.server.schema;
 
     dispatch(DbAction.fetchDatabasesIfNeeded());
-    dispatch(fetchTablesIfNeeded(lastConnectedDB));
     dispatch(fetchSchemasIfNeeded(lastConnectedDB));
-    dispatch(fetchViewsIfNeeded(lastConnectedDB));
-    dispatch(fetchRoutinesIfNeeded(lastConnectedDB));
+    dispatch(fetchTablesIfNeeded(lastConnectedDB, schema));
+    dispatch(fetchViewsIfNeeded(lastConnectedDB, schema));
+    dispatch(fetchRoutinesIfNeeded(lastConnectedDB, schema));
 
     this.setMenus();
   }
@@ -144,7 +145,10 @@ class QueryBrowserContainer extends Component {
   }
 
   onExecuteDefaultQuery(database, table) {
-    this.props.dispatch(QueryActions.executeDefaultSelectQueryIfNeeded(database.name, table.name));
+    const schema = this.props.connections.server.schema;
+    this.props.dispatch(
+      QueryActions.executeDefaultSelectQueryIfNeeded(database.name, table.name, schema)
+    );
   }
 
   onPromptCancelClick() {
@@ -158,12 +162,16 @@ class QueryBrowserContainer extends Component {
   }
 
   onSelectTable(database, table) {
-    this.props.dispatch(fetchTableColumnsIfNeeded(database.name, table.name));
-    this.props.dispatch(fetchTableTriggersIfNeeded(database.name, table.name));
+    const schema = this.props.connections.server.schema;
+    this.props.dispatch(fetchTableColumnsIfNeeded(database.name, table.name, schema));
+    this.props.dispatch(fetchTableTriggersIfNeeded(database.name, table.name, schema));
   }
 
   onGetSQLScript(database, item, actionType, objectType) {
-    this.props.dispatch(getSQLScriptIfNeeded(database.name, item.name, actionType, objectType));
+    const schema = this.props.connections.server.schema;
+    this.props.dispatch(
+      getSQLScriptIfNeeded(database.name, item.name, actionType, objectType, schema)
+    );
   }
 
   onSQLChange (sqlQuery) {
@@ -262,10 +270,11 @@ class QueryBrowserContainer extends Component {
   }
 
   fetchTableDiagramData(database, tables) {
-    const { dispatch } = this.props;
+    const { dispatch, connections } = this.props;
+    const schema = connections.server.schema;
     tables.forEach((item) => {
-      dispatch(fetchTableColumnsIfNeeded(database, item));
-      dispatch(fetchTableKeysIfNeeded(database, item));
+      dispatch(fetchTableColumnsIfNeeded(database, item, schema));
+      dispatch(fetchTableKeysIfNeeded(database, item, schema));
     });
   }
 

--- a/src/renderer/reducers/index.js
+++ b/src/renderer/reducers/index.js
@@ -3,6 +3,7 @@ import databases from './databases';
 import servers from './servers';
 import queries from './queries';
 import connections from './connections';
+import schemas from './schemas';
 import tables from './tables';
 import status from './status';
 import views from './views';
@@ -18,6 +19,7 @@ const rootReducer = combineReducers({
   servers,
   queries,
   connections,
+  schemas,
   tables,
   status,
   views,

--- a/src/renderer/reducers/schemas.js
+++ b/src/renderer/reducers/schemas.js
@@ -1,0 +1,69 @@
+import * as connTypes from '../actions/connections';
+import * as dbTypes from '../actions/databases';
+import * as queryTypes from '../actions/queries';
+import * as types from '../actions/schemas';
+
+
+const INITIAL_STATE = {
+  isFetching: false,
+  didInvalidate: false,
+  itemsByDatabase: {},
+  selectedTablesForDiagram: [],
+};
+
+
+const COMMANDS_TRIGER_REFRESH = ['CREATE_SCHEMA', 'DROP_SCHEMA'];
+
+
+export default function (state = INITIAL_STATE, action) {
+  switch (action.type) {
+    case connTypes.CONNECTION_REQUEST: {
+      return action.isServerConnection
+        ? { ...INITIAL_STATE, didInvalidate: true }
+        : state;
+    }
+    case types.FETCH_SCHEMAS_REQUEST: {
+      return { ...state, isFetching: true, didInvalidate: false, error: null };
+    }
+    case types.FETCH_SCHEMAS_SUCCESS: {
+      return {
+        ...state,
+        isFetching: false,
+        didInvalidate: false,
+        itemsByDatabase: {
+          ...state.itemsByDatabase,
+          [action.database]: action.schemas.map(name => ({ name })),
+        },
+        error: null,
+      };
+    }
+    case types.FETCH_SCHEMAS_FAILURE: {
+      return {
+        ...state,
+        isFetching: false,
+        didInvalidate: true,
+        error: action.error,
+      };
+    }
+    case queryTypes.EXECUTE_QUERY_SUCCESS: {
+      return {
+        ...state,
+        didInvalidate: action.results
+          .some(({ command }) => COMMANDS_TRIGER_REFRESH.includes(command)),
+      };
+    }
+    case dbTypes.REFRESH_DATABASES: {
+      return {
+        ...state,
+        didInvalidate: true,
+      };
+    }
+    case dbTypes.CLOSE_DATABASE_DIAGRAM: {
+      return {
+        ...state,
+        selectedSchemasForDiagram: null,
+      };
+    }
+    default : return state;
+  }
+}


### PR DESCRIPTION
Hi, 

here is the first step for schema support.
Let's add a field in the connection screen , then use it in all selecting objects queries.

Then later we can work to add a bit of interactivity to select the schema.
i've also added the schema completion for the query.
but note: the custom query part is not affected by the schema "selection".

need https://github.com/sqlectron/sqlectron-core/pull/33

ref #153 
what do you guys think ?
