### PR TITLE
highlight db on switching tab

### DIFF
--- a/src/renderer/components/database-list-item.jsx
+++ b/src/renderer/components/database-list-item.jsx
@@ -32,6 +32,7 @@ export default class DatabaseListItem extends Component {
     views: PropTypes.array,
     functions: PropTypes.array,
     procedures: PropTypes.array,
+    currentDB: PropTypes.string,
     database: PropTypes.object.isRequired,
     onExecuteDefaultQuery: PropTypes.func.isRequired,
     onSelectTable: PropTypes.func.isRequired,
@@ -138,6 +139,7 @@ export default class DatabaseListItem extends Component {
       onExecuteDefaultQuery,
       onSelectTable,
       onGetSQLScript,
+      currentDB,
     } = this.props;
 
     let filteredTables;
@@ -157,7 +159,7 @@ export default class DatabaseListItem extends Component {
     }
 
     return (
-      <div className="item">
+      <div className={`item ${currentDB === database.name ? 'active' : ''}`}>
         {this.renderHeader(database)}
         <div className="ui list" style={cssStyleItems}>
           <div className="item" style={cssStyleItems}>

--- a/src/renderer/components/database-list.jsx
+++ b/src/renderer/components/database-list.jsx
@@ -6,6 +6,7 @@ export default class DatabaseList extends Component {
   static propTypes = {
     client: PropTypes.string.isRequired,
     databases: PropTypes.array.isRequired,
+    currentDB: PropTypes.string,
     isFetching: PropTypes.bool.isRequired,
     tablesByDatabase: PropTypes.object.isRequired,
     columnsByTable: PropTypes.object.isRequired,
@@ -47,6 +48,7 @@ export default class DatabaseList extends Component {
       onGetSQLScript,
       onRefreshDatabase,
       onShowDiagramModal,
+      currentDB,
     } = this.props;
 
     if (isFetching) {
@@ -68,6 +70,7 @@ export default class DatabaseList extends Component {
           <DatabaseListItem
             ref={database.name}
             key={database.name}
+            currentDB={currentDB}
             client={client}
             database={database}
             tables={tablesByDatabase[database.name]}

--- a/src/renderer/containers/query-browser.jsx
+++ b/src/renderer/containers/query-browser.jsx
@@ -507,6 +507,7 @@ class QueryBrowserContainer extends Component {
       views,
       routines,
     } = this.props;
+    const currentDB = this.getCurrentQuery() ? this.getCurrentQuery().database : null;
 
     if (connections.waitingPrivateKeyPassphrase) {
       return (
@@ -566,6 +567,7 @@ class QueryBrowserContainer extends Component {
                   ref="databaseList"
                   client={connections.server.client}
                   databases={filteredDatabases}
+                  currentDB={currentDB}
                   isFetching={databases.isFetching}
                   tablesByDatabase={tables.itemsByDatabase}
                   columnsByTable={columns.columnsByTable}


### PR DESCRIPTION
As the tab is related to to the database select in the left panel, 
i thought it would be a good idea to highlight the current tab's database, to make a parallel between the two...

here is a gif explaining that.

![test_switch](https://cloud.githubusercontent.com/assets/177003/19400962/edfd1d06-9258-11e6-8154-fc888c6ec22e.gif)

