### PR TITLE
Issue 278 - change keybinding for window reload

### DIFF
--- a/docs/app/keyboard-shortcuts.md
+++ b/docs/app/keyboard-shortcuts.md
@@ -29,7 +29,7 @@
 | <kbd>Ctrl</kbd>-<kbd>T</kbd> | <kbd>Command</kbd>-<kbd>T</kbd> | New Tab |
 | <kbd>Ctrl</kbd>-<kbd>W</kbd> | <kbd>Command</kbd>-<kbd>W</kbd> | Close Tab |
 | <kbd>Ctrl</kbd>-<kbd>S</kbd> | <kbd>Command</kbd>-<kbd>S</kbd> | Save Query |
-| <kbd>Ctrl</kbd>-<kbd>Enter</kbd> | <kbd>Command</kbd>-<kbd>Enter</kbd> | Execute Query |
+| <kbd>Ctrl</kbd>-<kbd>Enter</kbd> or <kbd>Ctrl</kbd>-<kbd>R</kbd> | <kbd>Command</kbd>-<kbd>Enter</kbd> or <kbd>Command</kbd>-<kbd>R</kbd> | Execute Query |
 | <kbd>Shift</kbd>-<kbd>Ctrl</kbd>-<kbd>0</kbd> | <kbd>Shift</kbd>-<kbd>Command</kbd>-<kbd>0</kbd> | Focus Query Editor |
 
 

--- a/docs/app/keyboard-shortcuts.md
+++ b/docs/app/keyboard-shortcuts.md
@@ -10,7 +10,7 @@
 | <kbd>Ctrl</kbd>-<kbd>C</kbd> | <kbd>Command</kbd>-<kbd>C</kbd> | Copy |
 | <kbd>Ctrl</kbd>-<kbd>V</kbd> | <kbd>Command</kbd>-<kbd>V</kbd> | Paste |
 | <kbd>Ctrl</kbd>-<kbd>A</kbd> | <kbd>Command</kbd>-<kbd>A</kbd> | Select All |
-| <kbd>Ctrl</kbd>-<kbd>R</kbd> | <kbd>Command</kbd>-<kbd>R</kbd> | Reload Application |
+| <kbd>Ctrl</kbd>-<kbd>Shift</kbd>-<kbd>R</kbd> | <kbd>Command</kbd>-<kbd>Shift</kbd>-<kbd>R</kbd> | Reload Application |
 | <kbd>Ctrl</kbd>-<kbd>Alt</kbd>-<kbd>I</kbd> | <kbd>Alt</kbd>-<kbd>Command</kbd>-<kbd>I</kbd> | Toggle DevTools |
 | | <kbd>Command</kbd>-<kbd>M</kbd> | Minimize Window |
 | | <kbd>Command</kbd>-<kbd>Shift</kbd>-<kbd>W</kbd> | Close Window |

--- a/src/browser/app.js
+++ b/src/browser/app.js
@@ -1,4 +1,4 @@
-import { app, dialog } from 'electron'; // eslint-disable-line import/no-unresolved
+import { app, dialog, globalShortcut } from 'electron'; // eslint-disable-line import/no-unresolved
 import { buildNewWindow } from './window';
 
 
@@ -17,6 +17,16 @@ app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
     app.quit();
   }
+});
+
+
+// This method will be called when Electron creates a new browser window
+app.on('browser-window-created', (item, win) => {
+  // Only one keybinding/accelerator can be set for each command in the menu.
+  // This registers more keybindings for commands already in the menus.
+  globalShortcut.register('CommandOrControl+R', () => {
+    win.webContents.send('sqlectron:query-execute');
+  });
 });
 
 

--- a/src/browser/menu/darwin.js
+++ b/src/browser/menu/darwin.js
@@ -129,7 +129,7 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
       submenu: [
         {
           label: 'Reload',
-          accelerator: 'Cmd+R',
+          accelerator: 'Cmd+Shift+R',
           click: (item, win) => win.webContents.reloadIgnoringCache(),
         },
         {

--- a/src/browser/menu/linux.js
+++ b/src/browser/menu/linux.js
@@ -97,7 +97,7 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
       submenu: [
         {
           label: 'Reload',
-          accelerator: 'Ctrl+R',
+          accelerator: 'Ctrl+Shift+R',
           click: (item, win) => win.webContents.reloadIgnoringCache(),
         },
         {

--- a/src/browser/menu/win32.js
+++ b/src/browser/menu/win32.js
@@ -97,7 +97,7 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
       submenu: [
         {
           label: 'Reload',
-          accelerator: 'Ctrl+R',
+          accelerator: 'Ctrl+Shift+R',
           click: (item, win) => win.webContents.reloadIgnoringCache(),
         },
         {


### PR DESCRIPTION
Hey everyone!  This is to resolve #278 

  - Keybinding to reload window is Ctrl/Cmd-Shift-R (to mimic behavior cache ignoring keybinding in Firefox and Chrome)
  - Ctrl/Cmd-R now also Executes query (keeping Ctrl/Cmd-Enter)

I may be wrong, but I don't thing multiple accelerators can be assigned in the Electron menus.  To get around this, I added an event listener for `browser-window-created` in `src/browser/app.js` that adds the duplicate shortcut to execute a query.

Any thoughts or changes needed?
Thanks!