### PR TITLE
Fix CommandOrControl+R to work only when window is active

### DIFF
--- a/src/browser/app.js
+++ b/src/browser/app.js
@@ -19,14 +19,22 @@ app.on('window-all-closed', () => {
   }
 });
 
+let queryExecuteCommandRegister;
 
-// This method will be called when Electron creates a new browser window
 app.on('browser-window-created', (item, win) => {
-  // Only one keybinding/accelerator can be set for each command in the menu.
-  // This registers more keybindings for commands already in the menus.
-  globalShortcut.register('CommandOrControl+R', () => {
-    win.webContents.send('sqlectron:query-execute');
-  });
+  queryExecuteCommandRegister = () => {
+    globalShortcut.register('CommandOrControl+R', () => {
+      win.webContents.send('sqlectron:query-execute');
+    });
+  };
+});
+
+app.on('browser-window-focus', (event) => {
+  queryExecuteCommandRegister();
+});
+
+app.on('browser-window-blur', () => {
+  globalShortcut.unregister('CommandOrControl+R');
 });
 
 


### PR DESCRIPTION
Close #287

Before the Ctrl + R or Command + R was a global command, this PR makes it only work when the window has focus...