### PR TITLE
Ovewrite reload shortcut without global settings

### DIFF
--- a/src/browser/app.js
+++ b/src/browser/app.js
@@ -1,4 +1,4 @@
-import { app, dialog, globalShortcut } from 'electron'; // eslint-disable-line import/no-unresolved
+import { app, dialog } from 'electron'; // eslint-disable-line import/no-unresolved
 import createLogger from './logger';
 import { buildNewWindow } from './window';
 
@@ -19,16 +19,6 @@ app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
     app.quit();
   }
-});
-
-
-// This method will be called when Electron creates a new browser window
-app.on('browser-window-created', (item, win) => {
-  // Only one keybinding/accelerator can be set for each command in the menu.
-  // This registers more keybindings for commands already in the menus.
-  globalShortcut.register('CommandOrControl+R', () => {
-    win.webContents.send('sqlectron:query-execute');
-  });
 });
 
 

--- a/src/browser/menu/darwin.js
+++ b/src/browser/menu/darwin.js
@@ -80,6 +80,11 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
           click: (item, win) => win.webContents.send('sqlectron:query-execute'),
         },
         {
+          label: 'Execute',
+          accelerator: 'Cmd+R',
+          click: (item, win) => win.webContents.send('sqlectron:query-execute'),
+        },
+        {
           label: 'Focus Query Editor',
           accelerator: 'Shift+Cmd+0',
           click: (item, win) => win.webContents.send('sqlectron:query-focus'),

--- a/src/browser/menu/linux.js
+++ b/src/browser/menu/linux.js
@@ -48,6 +48,11 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
           click: (item, win) => win.webContents.send('sqlectron:query-execute'),
         },
         {
+          label: 'Execute',
+          accelerator: 'Ctrl+R',
+          click: (item, win) => win.webContents.send('sqlectron:query-execute'),
+        },
+        {
           label: 'Focus Query Editor',
           accelerator: 'Shift+Ctrl+0',
           click: (item, win) => win.webContents.send('sqlectron:query-focus'),

--- a/src/browser/menu/win32.js
+++ b/src/browser/menu/win32.js
@@ -48,6 +48,11 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
           click: (item, win) => win.webContents.send('sqlectron:query-execute'),
         },
         {
+          label: 'Execute',
+          accelerator: 'Ctrl+R',
+          click: (item, win) => win.webContents.send('sqlectron:query-execute'),
+        },
+        {
           label: 'Focus Query Editor',
           accelerator: 'Shift+Ctrl+0',
           click: (item, win) => win.webContents.send('sqlectron:query-focus'),


### PR DESCRIPTION
Global shortcut should be avoided since we don't want to the shortcut work on the OS global scope.