### PR TITLE
Use a File Path Dialogue Window to add a local Database

### DIFF
--- a/src/renderer/components/server-modal-form.jsx
+++ b/src/renderer/components/server-modal-form.jsx
@@ -320,7 +320,7 @@ export default class ServerModalForm extends Component {
                 placeholder="Database"
                 value={this.state.database || ''}
                 onChange={::this.handleChange} />
-              {this.isFeatureDisabled('server:password') &&
+              { this.state.client === "sqlite" &&
                 <label htmlFor="file.database" className="ui icon button btn-file">
                   <i className="file outline icon" />
                   <input

--- a/src/renderer/components/server-modal-form.jsx
+++ b/src/renderer/components/server-modal-form.jsx
@@ -314,7 +314,7 @@ export default class ServerModalForm extends Component {
           </div>
           <div className={`four wide field ${this.highlightError('database')}`}>
             <label>Database/Keyspace</label>
-            <div className="ui action input">
+            <div className={this.state.client === "sqlite" && "ui action input"}>
               <input type="text"
                 name="database"
                 placeholder="Database"

--- a/src/renderer/components/server-modal-form.jsx
+++ b/src/renderer/components/server-modal-form.jsx
@@ -314,11 +314,22 @@ export default class ServerModalForm extends Component {
           </div>
           <div className={`four wide field ${this.highlightError('database')}`}>
             <label>Database/Keyspace</label>
-            <input type="text"
-              name="database"
-              placeholder="Database"
-              value={this.state.database || ''}
-              onChange={::this.handleChange} />
+            <div className="ui action input">
+              <input type="text"
+                name="database"
+                placeholder="Database"
+                value={this.state.database || ''}
+                onChange={::this.handleChange} />
+              <label htmlFor="file.database" className="ui icon button btn-file">
+                <i className="file outline icon" />
+                <input
+                  type="file"
+                  id="file.database"
+                  name="file.database"
+                  onChange={::this.handleChange}
+                  style={{ display: 'none' }} />
+              </label>
+            </div>
           </div>
           <div className={`four wide field ${this.highlightError('schema')}`}>
             <label>Schema</label>

--- a/src/renderer/components/server-modal-form.jsx
+++ b/src/renderer/components/server-modal-form.jsx
@@ -320,15 +320,17 @@ export default class ServerModalForm extends Component {
                 placeholder="Database"
                 value={this.state.database || ''}
                 onChange={::this.handleChange} />
-              <label htmlFor="file.database" className="ui icon button btn-file">
-                <i className="file outline icon" />
-                <input
-                  type="file"
-                  id="file.database"
-                  name="file.database"
-                  onChange={::this.handleChange}
-                  style={{ display: 'none' }} />
-              </label>
+              {this.isFeatureDisabled('server:password') &&
+                <label htmlFor="file.database" className="ui icon button btn-file">
+                  <i className="file outline icon" />
+                  <input
+                    type="file"
+                    id="file.database"
+                    name="file.database"
+                    onChange={::this.handleChange}
+                    style={{ display: 'none' }} />
+                </label>
+              }
             </div>
           </div>
           <div className={`four wide field ${this.highlightError('schema')}`}>


### PR DESCRIPTION
When adding a new local database, the filepath can be chosen from a file dialogue instead of writing it out by hand.

#### Before

In the Database/Keyspace input, the filepath of a database had to be selected manually.

![before](https://user-images.githubusercontent.com/25739586/27031035-f1088f52-4f6e-11e7-8b2f-3312c046e77c.png)


#### After

Now, it can be selected via a file path dialogue.

![after](https://user-images.githubusercontent.com/25739586/27031228-b7129058-4f6f-11e7-853b-0d1043306d7d.png)




resolves #303 