### PR TITLE
Add open query from file option (resolves #223)

### DIFF
--- a/src/browser/menu/darwin.js
+++ b/src/browser/menu/darwin.js
@@ -75,6 +75,11 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
           accelerator: 'Cmd+S',
           click: (item, win) => sendMessage(win, 'sqlectron:save-query'),
         },
+        {
+          label: 'Open Query',
+          accelerator: 'Cmd+O',
+          click: (item, win) => sendMessage(win, 'sqlectron:open-query'),
+        },
       ],
     },
     {

--- a/src/browser/menu/linux.js
+++ b/src/browser/menu/linux.js
@@ -36,6 +36,11 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
           click: (item, win) => sendMessage(win, 'sqlectron:save-query'),
         },
         {
+          label: 'Open Query',
+          accelerator: 'Ctrl+O',
+          click: (item, win) => sendMessage(win, 'sqlectron:open-query'),
+        },
+        {
           type: 'separator',
         },
         {

--- a/src/browser/menu/win32.js
+++ b/src/browser/menu/win32.js
@@ -36,6 +36,11 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
           click: (item, win) => sendMessage(win, 'sqlectron:save-query'),
         },
         {
+          label: 'Open Query',
+          accelerator: 'Ctrl+O',
+          click: (item, win) => sendMessage(win, 'sqlectron:open-query'),
+        },
+        {
           type: 'separator',
         },
         {

--- a/src/renderer/actions/queries.js
+++ b/src/renderer/actions/queries.js
@@ -5,7 +5,7 @@ import csvStringify from 'csv-stringify';
 import { clipboard } from 'electron'; // eslint-disable-line import/no-unresolved
 import { getCurrentDBConn, getDBConnByName } from './connections';
 import { rowsValuesToString } from '../utils/convert';
-import { showSaveDialog, saveFile } from '../utils/file-handler';
+import * as fileHandler from '../utils/file-handler';
 import wait from '../utils/wait';
 
 
@@ -25,6 +25,9 @@ export const COPY_QUERY_RESULT_TO_CLIPBOARD_FAILURE = 'COPY_QUERY_RESULT_TO_CLIP
 export const SAVE_QUERY_REQUEST = 'SAVE_QUERY_REQUEST';
 export const SAVE_QUERY_SUCCESS = 'SAVE_QUERY_SUCCESS';
 export const SAVE_QUERY_FAILURE = 'SAVE_QUERY_FAILURE';
+export const OPEN_QUERY_REQUEST = 'OPEN_QUERY_REQUEST';
+export const OPEN_QUERY_SUCCESS = 'OPEN_QUERY_SUCCESS';
+export const OPEN_QUERY_FAILURE = 'OPEN_QUERY_FAILURE';
 export const UPDATE_QUERY = 'UPDATE_QUERY';
 
 
@@ -144,17 +147,37 @@ export function saveQuery () {
         { name: 'All Files', extensions: ['*'] },
       ];
 
-      let filename = (currentQuery.filename || await showSaveDialog(filters));
+      let filename = (currentQuery.filename || await fileHandler.showSaveDialog(filters));
       if (path.extname(filename) !== '.sql') {
         filename += '.sql';
       }
 
-      await saveFile(filename, currentQuery.query);
+      await fileHandler.saveFile(filename, currentQuery.query);
       const name = path.basename(filename, '.sql');
 
       dispatch({ type: SAVE_QUERY_SUCCESS, name, filename });
     } catch (error) {
       dispatch({ type: SAVE_QUERY_FAILURE, error });
+    }
+  };
+}
+
+export function openQuery () {
+  return async (dispatch) => {
+    dispatch({ type: OPEN_QUERY_REQUEST });
+    try {
+      const filters = [
+        { name: 'SQL', extensions: ['sql'] },
+      ];
+
+      const [filename] = await fileHandler.showOpenDialog(filters);
+      const name = path.basename(filename, '.sql');
+
+      const query = await fileHandler.openFile(filename);
+
+      dispatch({ type: OPEN_QUERY_SUCCESS, name, query });
+    } catch (error) {
+      dispatch({ type: OPEN_QUERY_FAILURE, error });
     }
   };
 }

--- a/src/renderer/containers/query-browser.jsx
+++ b/src/renderer/containers/query-browser.jsx
@@ -268,6 +268,7 @@ class QueryBrowserContainer extends Component {
       'sqlectron:new-tab': () => this.newTab(),
       'sqlectron:close-tab': () => this.closeTab(),
       'sqlectron:save-query': () => this.saveQuery(),
+      'sqlectron:open-query': () => this.openQuery(),
       'sqlectron:query-focus': () => this.focusQuery(),
       'sqlectron:toggle-database-search': () => this.toggleDatabaseSearch(),
       'sqlectron:toggle-database-objects-search': () => this.toggleDatabaseObjectsSearch(),
@@ -294,6 +295,10 @@ class QueryBrowserContainer extends Component {
 
   saveQuery() {
     this.props.dispatch(QueryActions.saveQuery());
+  }
+
+  openQuery() {
+    this.props.dispatch(QueryActions.openQuery());
   }
 
   copyToClipboard (rows, type) {

--- a/src/renderer/reducers/queries.js
+++ b/src/renderer/reducers/queries.js
@@ -135,12 +135,18 @@ export default function (state = INITIAL_STATE, action) {
         filename: action.filename,
       });
     }
+    case types.OPEN_QUERY_SUCCESS: {
+      return changeStateByCurrentQuery(state, {
+        name: action.name,
+        query: action.query,
+      });
+    }
+    case types.OPEN_QUERY_FAILURE:
     case types.SAVE_QUERY_FAILURE: {
       return changeStateByCurrentQuery(state, {
         error: action.error,
       });
     }
-
     default : return state;
   }
 }


### PR DESCRIPTION
Added option for user to open `.sql ` files in current active tab.

User can open sql from file with option in window menu, under File -> Open Query (right next to Save Query option); or with shortcuts `Cmd+O` for MacOS and `Ctrl+O` for Linux/Win users.

Tab name is automatically updated with file name (extension excluded of course). 

I didn't save filename into redux state because it's used for saving as well. Maybe user does not want to save opened SQL under same filename. When we add 'Save As' option, persisting filename to redux state will make sense.