### PR TITLE
Fix #296 - sidemenu resizing

### DIFF
--- a/src/renderer/containers/query-browser.jsx
+++ b/src/renderer/containers/query-browser.jsx
@@ -587,7 +587,7 @@ class QueryBrowserContainer extends Component {
           <div id="sidebar" style={STYLES.sidebar}>
             <ResizableBox className="react-resizable react-resizable-ew-resize"
               onResizeStop={(event, { size }) => this.setState({ sideBarWidth: size.width })}
-              width={SIDEBAR_WIDTH}
+              width={this.state.sideBarWidth || SIDEBAR_WIDTH}
               height={NaN}
               minConstraints={[SIDEBAR_WIDTH, 300]}
               maxConstraints={[750, 10000]}>


### PR DESCRIPTION
Fixes bug that disabled users from resizing side menu. Probably didn't work for quite some while, since width used was fixed, while value that was changed through state haven't been used.