### PR TITLE
Preventing state loss on switching tabs

### DIFF
--- a/src/renderer/components/query.jsx
+++ b/src/renderer/components/query.jsx
@@ -58,6 +58,7 @@ export default class Query extends Component {
     onCopyToClipboardClick: PropTypes.func.isRequired,
     onSQLChange: PropTypes.func.isRequired,
     onSelectionChange: PropTypes.func.isRequired,
+    editorName: PropTypes.string.isRequired,
   }
 
   constructor(props, context) {
@@ -271,7 +272,7 @@ export default class Query extends Component {
             <AceEditor
               mode="sql"
               theme="github"
-              name="querybox"
+              name={this.props.editorName}
               height="100%"
               width="100%"
               ref="queryBoxTextarea"

--- a/src/renderer/containers/query-browser.jsx
+++ b/src/renderer/containers/query-browser.jsx
@@ -473,6 +473,7 @@ class QueryBrowserContainer extends Component {
         <TabPanel key={queryId}>
           <Query
             ref={`queryBox_${queryId}`}
+            editorName={`querybox${queryId}`}
             client={connections.server.client}
             allowCancel={allowCancel}
             query={query}
@@ -504,7 +505,7 @@ class QueryBrowserContainer extends Component {
     const selectedIndex = queries.queryIds.indexOf(queries.currentQueryId);
     const isTabsFitOnScreen = this.tabListTotalWidthChildren >= this.tabListTotalWidth;
     return (
-      <Tabs onSelect={::this.handleSelectTab} selectedIndex={selectedIndex}>
+      <Tabs onSelect={::this.handleSelectTab} selectedIndex={selectedIndex} forceRenderTabPanel>
         <div id="tabs-nav-wrapper" className="ui pointing secondary menu">
           {isTabsFitOnScreen &&
             <button className="ui icon button"


### PR DESCRIPTION
In regards to #274 

This change causes each open tab to remain in the DOM instead of being unmounted when tabs are changed. As a result, each `AceEditor` component needs a unique name, and so `query-browser` is creating one by appending the unique `queryId` to the string `querybox` and passing it as a prop.