### PR TITLE
Grouping database items under schema dropdowns

### DIFF
--- a/src/renderer/components/collapse-icon.jsx
+++ b/src/renderer/components/collapse-icon.jsx
@@ -1,0 +1,13 @@
+import React, { PropTypes } from 'react';
+
+const CollapseIcon = ({ arrowDirection }) =>
+  (<i
+    className={`${arrowDirection} triangle icon`}
+    style={{ float: 'left', margin: '0 0.15em 0 -1em' }}
+  />);
+
+CollapseIcon.propTypes = {
+  arrowDirection: PropTypes.string.isRequired,
+};
+
+export default CollapseIcon;

--- a/src/renderer/components/database-item.jsx
+++ b/src/renderer/components/database-item.jsx
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from 'react';
+import CollapseIcon from './collapse-icon.jsx';
 import TableSubmenu from './table-submenu.jsx';
 import { remote } from 'electron'; // eslint-disable-line import/no-unresolved
 import { sqlectron } from '../../browser/remote';
@@ -137,13 +138,7 @@ export default class DatabaseItem extends Component {
       ? () => { onSelectItem(database, item); this.toggleTableCollapse(); }
       : () => {};
 
-    const collapseCssClass = this.state.tableCollapsed ? 'down' : 'right';
-    const collapseIcon = (
-      <i
-        className={`${collapseCssClass} triangle icon`}
-        style={{ float: 'left', margin: '0 0.15em 0 -1em' }}
-      ></i>
-    );
+    const collapseArrowDirection = this.state.tableCollapsed ? 'down' : 'right';
     const tableIcon = (
       <i className="table icon" style={{ float: 'left', margin: '0 0.3em 0 0' }}></i>
     );
@@ -158,7 +153,10 @@ export default class DatabaseItem extends Component {
           className="item"
           onClick={onSingleClick}
           onContextMenu={::this.onContextMenu}>
-          {dbObjectType === 'Table' ? collapseIcon : null}
+          {dbObjectType === 'Table'
+            ? <CollapseIcon arrowDirection={collapseArrowDirection} />
+            : null
+          }
           {dbObjectType === 'Table' ? tableIcon : null}
           {fullName}
         </span>

--- a/src/renderer/components/database-list-item-metadata.jsx
+++ b/src/renderer/components/database-list-item-metadata.jsx
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from 'react';
+import CollapseIcon from './collapse-icon.jsx';
 import DatabaseItem from './database-item.jsx';
-
+import groupBy from 'lodash.groupby';
 
 const STYLE = {
   header: { fontSize: '0.85em', color: '#636363' },
@@ -26,7 +27,7 @@ export default class DbMetadataList extends Component {
 
   constructor(props, context) {
     super(props, context);
-    this.state = {};
+    this.state = { tableCollapsed: {} };
   }
 
   componentWillReceiveProps(nextProps) {
@@ -37,6 +38,14 @@ export default class DbMetadataList extends Component {
 
   toggleCollapse() {
     this.setState({ collapsed: !this.state.collapsed });
+  }
+
+  handleTableCollapse(key) {
+    this.setState({
+      tableCollapsed: {
+        ...this.state.tableCollapsed,
+        [key]: !this.state.tableCollapsed[key] },
+    });
   }
 
   renderHeader() {
@@ -82,33 +91,60 @@ export default class DbMetadataList extends Component {
       );
     }
 
-    return items.map(item => {
-      const hasChildElements = !!onSelectItem;
+    const grouped = groupBy(items, 'schema');
 
-      const cssStyle = { ...STYLE.item };
-      if (this.state.collapsed) {
-        cssStyle.display = 'none';
-      }
-      cssStyle.cursor = hasChildElements ? 'pointer' : 'default';
+    return Object.keys(grouped).map(key => {
+      const hasGroup = !(key === 'undefined' || key === undefined || key === '');
+      const hasChildren = grouped[key].length;
+      const isCollapsed = !this.state.tableCollapsed[key];
+      const renderChildren = !hasGroup || (hasChildren && !isCollapsed);
+      const collapseArrowDirection = isCollapsed ? 'right' : 'down';
+      const header = hasGroup
+        ? <span
+          style={{ ...STYLE.item, cursor: hasChildren ? 'pointer' : 'default' }}
+          className="item"
+          onClick={() => this.handleTableCollapse(key)}>
+          {hasChildren ? <CollapseIcon arrowDirection={collapseArrowDirection} /> : null}
+          {key}
+        </span>
+        : null;
 
-      const { schema, name } = item;
-      const fullName = schema ? `${schema}.${name}` : name;
+      const body = renderChildren
+        ? grouped[key].map(item => {
+          const hasChildElements = !!onSelectItem;
+
+          const cssStyle = { ...STYLE.item, marginLeft: hasGroup ? '15px' : '0px' };
+          if (this.state.collapsed) {
+            cssStyle.display = 'none';
+          }
+          cssStyle.cursor = hasChildElements ? 'pointer' : 'default';
+
+          const { schema, name } = item;
+          const fullName = schema ? `${schema}.${name}` : name;
+
+          return (
+            <DatabaseItem
+              key={`${key}.${title}.${database.name}.${fullName}`}
+              client={client}
+              database={database}
+              item={item}
+              dbObjectType={this.props.title.slice(0, -1)}
+              style={cssStyle}
+              columnsByTable={this.props.columnsByTable}
+              triggersByTable={this.props.triggersByTable}
+              indexesByTable={this.props.indexesByTable}
+              onSelectItem={onSelectItem}
+              onExecuteDefaultQuery={onExecuteDefaultQuery}
+              onGetSQLScript={onGetSQLScript} />
+          );
+        })
+      : null;
 
       return (
-        <DatabaseItem
-          key={`${title}.${database.name}.${fullName}`}
-          client={client}
-          database={database}
-          item={item}
-          dbObjectType={this.props.title.slice(0, -1)}
-          style={cssStyle}
-          columnsByTable={this.props.columnsByTable}
-          triggersByTable={this.props.triggersByTable}
-          indexesByTable={this.props.indexesByTable}
-          onSelectItem={onSelectItem}
-          onExecuteDefaultQuery={onExecuteDefaultQuery}
-          onGetSQLScript={onGetSQLScript} />
-      );
+        <div key={`list-item.${key}.${title}.${database.name}`}>
+          {header}
+          {body}
+        </div>);
     });
   }
 

--- a/src/renderer/components/database-list-item-metadata.jsx
+++ b/src/renderer/components/database-list-item-metadata.jsx
@@ -113,7 +113,7 @@ export default class DbMetadataList extends Component {
         ? grouped[key].map(item => {
           const hasChildElements = !!onSelectItem;
 
-          const cssStyle = { ...STYLE.item, marginLeft: hasGroup ? '15px' : '0px' };
+          const cssStyle = { ...STYLE.item, marginLeft: hasGroup ? '0.5em' : '0px' };
           if (this.state.collapsed) {
             cssStyle.display = 'none';
           }


### PR DESCRIPTION
Referenced in #316 

I added in `database-list-item-metadata` a grouping on the key `schema` of all the elements in the list.

The way it's implemented, if the result of the group is `undefined`, the string `'undefined'` or an empty string (`''`) it should continue rendering as it currently does, that is, in a long, flat list.

I also modified `database-item` slightly as I borrowed code from there (the collapse arrow) and pulled that borrowed code out into a new component named `collapse-icon`, which renders the collapse icon based on a direction prop passed in.

`database-list-item-metadata`, when grouping by `schema` will render a list of `schemas` with dropdowns to the left. When clicking one, a list of all the items with that schema will then be rendered, with a `leftPadding` of 15px to differentiate that it's a sublist.

I don't have a docker instance of a database without schema support so I'd really appreciate anyone testing that for me if possible. I tested it by just making the key I was grouping on a random string, but I don't know what the app puts in the `schema` field in the data (if anything) for databases that don't have schema support.