### PR TITLE
Made resize span for database list full height, changed cursor

### DIFF
--- a/src/renderer/components/react-resizable.css
+++ b/src/renderer/components/react-resizable.css
@@ -47,3 +47,8 @@
   box-sizing: border-box;
   cursor: se-resize;
 }
+
+.react-resizable-handle {
+  height: 100%;
+  cursor: col-resize !important;
+}


### PR DESCRIPTION
In regards to #348

Grabbed the `react-resize-handle` class and made it 100% high so it follows the entire line.

I thought I'd try a different cursor and see how you felt about it. 

To me the grab icon means "I can move this thing around the screen", not "I can resize a column" so I changed it to `col-resize` and gave it the `!important` tag to overwrite the one given by `react-resizable`