### PR TITLE
Saving tabs and queries to disk by server & automatically reloading on server selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,8 @@
     "lodash.debounce": "^4.0.8",
     "lodash.groupby": "^4.6.0",
     "lodash.isplainobject": "^4.0.6",
+    "lodash.mapvalues": "^4.6.0",
+    "lodash.omit": "^4.5.0",
     "lodash.set": "^4.3.2",
     "lodash.template": "^4.4.0",
     "lodash.trim": "^4.5.1",

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "lodash.template": "^4.4.0",
     "lodash.trim": "^4.5.1",
     "lodash.union": "^4.6.0",
+    "lodash.uniq": "^4.5.0",
     "minimist": "^1.2.0",
     "node-sass": "^3.4.2",
     "react": "^15.0.1",

--- a/src/renderer/actions/connections.js
+++ b/src/renderer/actions/connections.js
@@ -59,8 +59,13 @@ export function restoreStoredQueries(id) {
       const databaseNames = uniq(
         Object.values(storedQueryState.queriesById).map(({ database }) => database)
       );
-      databaseNames.forEach(db => dispatch(connect(id, db)));
-
+      databaseNames.forEach((db, idx) => {
+        if (idx === 0) {
+          dispatch(connect(id, db, false, undefined, true));
+        } else {
+          dispatch(connect(id, db));
+        }
+      });
       dispatch({ type: SET_STORED_QUERIES, storedQueryState });
     } else {
       dispatch(connect(id));
@@ -68,7 +73,8 @@ export function restoreStoredQueries(id) {
   };
 }
 
-export function connect (id, databaseName, reconnecting = false, sshPassphrase) {
+export function connect (id, databaseName, reconnecting = false,
+  sshPassphrase, isServerConnection = false) {
   return async (dispatch, getState) => {
     let server;
     let dbConn;
@@ -100,7 +106,7 @@ export function connect (id, databaseName, reconnecting = false, sshPassphrase) 
         server,
         database,
         reconnecting,
-        isServerConnection: !databaseName,
+        isServerConnection: isServerConnection || !databaseName,
       });
 
       if (!serverSession) {

--- a/src/renderer/actions/connections.js
+++ b/src/renderer/actions/connections.js
@@ -1,5 +1,5 @@
 import { sqlectron } from '../../browser/remote';
-
+import getCurrentServerId from '../utils/getCurrentServerId';
 
 export const CLOSE_CONNECTION = 'CLOSE_CONNECTION';
 export const CONNECTION_REQUEST = 'CONNECTION_REQUEST';
@@ -9,7 +9,6 @@ export const CONNECTION_REQUIRE_SSH_PASSPHRASE = 'CONNECTION_REQUIRE_SSH_PASSPHR
 export const TEST_CONNECTION_REQUEST = 'TEST_CONNECTION_REQUEST';
 export const TEST_CONNECTION_SUCCESS = 'TEST_CONNECTION_SUCCESS';
 export const TEST_CONNECTION_FAILURE = 'TEST_CONNECTION_FAILURE';
-
 
 let serverSession;
 export function getCurrentDBConn ({ queries } = {}) {
@@ -39,6 +38,19 @@ export function getDBConnByName(database) {
   return dbConn;
 }
 
+const getStoredQueryState = state => {
+  const currentServerId = getCurrentServerId(state);
+  try {
+    const storedQueryState = state.config.data.queries[currentServerId];
+    if (storedQueryState && Object.keys(storedQueryState).length > 0) {
+      return storedQueryState;
+    }
+
+    return null;
+  } catch (err) {
+    return null;
+  }
+};
 
 export function connect (id, databaseName, reconnecting = false, sshPassphrase) {
   return async (dispatch, getState) => {
@@ -98,7 +110,15 @@ export function connect (id, databaseName, reconnecting = false, sshPassphrase) 
       dbConn = serverSession.createConnection(database);
       await dbConn.connect();
 
-      dispatch({ type: CONNECTION_SUCCESS, server, database, config, reconnecting });
+      const connectionSuccessAction =
+        { type: CONNECTION_SUCCESS, server, database, config, reconnecting };
+      const storedQueryState = await getStoredQueryState(getState());
+
+      if (storedQueryState) {
+        dispatch({ ...connectionSuccessAction, storedQueryState });
+      } else {
+        dispatch(connectionSuccessAction);
+      }
     } catch (error) {
       dispatch({ type: CONNECTION_FAILURE, server, database, error });
       if (dbConn) {

--- a/src/renderer/actions/queries.js
+++ b/src/renderer/actions/queries.js
@@ -98,6 +98,7 @@ const updateStoredQuery = async (dispatch, state) => {
       ...currentConfig.queries,
       [selectedServerId]: {
         ...state.queries,
+        selectedQuery: null,
         queriesById: mapValues(
           state.queries.queriesById,
           q => ({ ...q, results: [], error: null })

--- a/src/renderer/actions/queries.js
+++ b/src/renderer/actions/queries.js
@@ -35,6 +35,7 @@ export const OPEN_QUERY_REQUEST = 'OPEN_QUERY_REQUEST';
 export const OPEN_QUERY_SUCCESS = 'OPEN_QUERY_SUCCESS';
 export const OPEN_QUERY_FAILURE = 'OPEN_QUERY_FAILURE';
 export const UPDATE_QUERY = 'UPDATE_QUERY';
+export const SET_STORED_QUERIES = 'SET_STORED_QUERIES';
 
 export function newQuery (database) {
   return { type: NEW_QUERY, database };

--- a/src/renderer/actions/routines.js
+++ b/src/renderer/actions/routines.js
@@ -1,4 +1,4 @@
-import { getCurrentDBConn } from './connections';
+import { getDBConnByName } from './connections';
 
 
 export const FETCH_ROUTINES_REQUEST = 'FETCH_ROUTINES_REQUEST';
@@ -24,10 +24,10 @@ function shouldFetchRoutines (state, database) {
 }
 
 function fetchRoutines (database, filter) {
-  return async (dispatch, getState) => {
+  return async (dispatch) => {
     dispatch({ type: FETCH_ROUTINES_REQUEST, database });
     try {
-      const dbConn = getCurrentDBConn(getState());
+      const dbConn = getDBConnByName(database);
       const routines = await dbConn.listRoutines(filter);
       dispatch({ type: FETCH_ROUTINES_SUCCESS, database, routines });
     } catch (error) {

--- a/src/renderer/actions/schemas.js
+++ b/src/renderer/actions/schemas.js
@@ -1,4 +1,4 @@
-import { getCurrentDBConn } from './connections';
+import { getDBConnByName } from './connections';
 
 
 export const FETCH_SCHEMAS_REQUEST = 'FETCH_SCHEMAS_REQUEST';
@@ -24,10 +24,10 @@ function shouldFetchSchemas (state, database) {
 
 
 function fetchSchemas (database) {
-  return async (dispatch, getState) => {
+  return async (dispatch) => {
     dispatch({ type: FETCH_SCHEMAS_REQUEST, database });
     try {
-      const dbConn = getCurrentDBConn(getState());
+      const dbConn = getDBConnByName(database);
       const schemas = await dbConn.listSchemas();
       dispatch({ type: FETCH_SCHEMAS_SUCCESS, database, schemas });
     } catch (error) {

--- a/src/renderer/actions/tables.js
+++ b/src/renderer/actions/tables.js
@@ -1,4 +1,4 @@
-import { getCurrentDBConn } from './connections';
+import { getDBConnByName } from './connections';
 
 
 export const FETCH_TABLES_REQUEST = 'FETCH_TABLES_REQUEST';
@@ -31,10 +31,10 @@ function shouldFetchTables (state, database) {
 
 
 function fetchTables (database, filter) {
-  return async (dispatch, getState) => {
+  return async (dispatch) => {
     dispatch({ type: FETCH_TABLES_REQUEST, database });
     try {
-      const dbConn = getCurrentDBConn(getState());
+      const dbConn = getDBConnByName(database);
       const tables = await dbConn.listTables(filter);
       dispatch({ type: FETCH_TABLES_SUCCESS, database, tables });
     } catch (error) {

--- a/src/renderer/actions/views.js
+++ b/src/renderer/actions/views.js
@@ -1,4 +1,4 @@
-import { getCurrentDBConn } from './connections';
+import { getDBConnByName } from './connections';
 
 
 export const FETCH_VIEWS_REQUEST = 'FETCH_VIEWS_REQUEST';
@@ -23,10 +23,10 @@ function shouldFetchViews (state, database) {
 }
 
 function fetchViews (database, filter) {
-  return async (dispatch, getState) => {
+  return async (dispatch) => {
     dispatch({ type: FETCH_VIEWS_REQUEST, database });
     try {
-      const dbConn = getCurrentDBConn(getState());
+      const dbConn = getDBConnByName(database);
       const views = await dbConn.listViews(filter);
       dispatch({ type: FETCH_VIEWS_SUCCESS, database, views });
     } catch (error) {

--- a/src/renderer/containers/query-browser.jsx
+++ b/src/renderer/containers/query-browser.jsx
@@ -92,7 +92,7 @@ class QueryBrowserContainer extends Component {
 
   componentWillMount () {
     const { dispatch, params } = this.props;
-    dispatch(ConnActions.connect(params.id));
+    dispatch(ConnActions.restoreStoredQueries(params.id));
   }
 
   componentDidMount() {

--- a/src/renderer/reducers/connections.js
+++ b/src/renderer/reducers/connections.js
@@ -1,3 +1,4 @@
+import { SET_STORED_QUERIES } from '../actions/queries';
 import * as types from '../actions/connections';
 import * as serverTypes from '../actions/servers';
 import { sqlectron } from '../../browser/remote';
@@ -16,6 +17,12 @@ const INITIAL_STATE = {
 
 export default function(state = INITIAL_STATE, action) {
   switch (action.type) {
+    case SET_STORED_QUERIES: {
+      return {
+        ...INITIAL_STATE,
+        connecting: true,
+      };
+    }
     case types.CONNECTION_REQUEST: {
       const { disabledFeatures } = CLIENTS.find(dbClient => dbClient.key === action.server.client);
       return {

--- a/src/renderer/reducers/queries.js
+++ b/src/renderer/reducers/queries.js
@@ -64,6 +64,7 @@ export default function (state = INITIAL_STATE, action) {
         return newState;
       }
 
+      newState.lastCreatedId = 0;
       return addNewQuery(newState, { ...action, database });
     }
     case types.EXECUTE_QUERY_REQUEST: {

--- a/src/renderer/reducers/queries.js
+++ b/src/renderer/reducers/queries.js
@@ -18,15 +18,18 @@ export default function (state = INITIAL_STATE, action) {
     case connTypes.CLOSE_CONNECTION: {
       return INITIAL_STATE;
     }
+    case types.SET_STORED_QUERIES: {
+      return {
+        ...INITIAL_STATE,
+        ...action.storedQueryState,
+      };
+    }
     case connTypes.CONNECTION_SUCCESS: {
-      if (action.storedQueryState) {
-        return {
-          ...INITIAL_STATE,
-          ...action.storedQueryState,
-        };
+      if (state.queryIds.length === 0) {
+        return addNewQuery(state, action);
       }
 
-      return addNewQuery(state, action);
+      return state;
     }
     case types.NEW_QUERY: {
       return addNewQuery(state, action);

--- a/src/renderer/reducers/queries.js
+++ b/src/renderer/reducers/queries.js
@@ -25,7 +25,9 @@ export default function (state = INITIAL_STATE, action) {
       };
     }
     case connTypes.CONNECTION_SUCCESS: {
-      if (state.queryIds.length === 0) {
+      const hasOpenTab = Object.values(state.queriesById).find(
+        ({ database }) => database === action.database);
+      if (!hasOpenTab) {
         return addNewQuery(state, action);
       }
 

--- a/src/renderer/reducers/queries.js
+++ b/src/renderer/reducers/queries.js
@@ -1,6 +1,6 @@
 import * as connTypes from '../actions/connections';
 import * as types from '../actions/queries';
-
+import omit from 'lodash.omit';
 
 const INITIAL_STATE = {
   lastCreatedId: 0,
@@ -18,7 +18,16 @@ export default function (state = INITIAL_STATE, action) {
     case connTypes.CLOSE_CONNECTION: {
       return INITIAL_STATE;
     }
-    case connTypes.CONNECTION_SUCCESS:
+    case connTypes.CONNECTION_SUCCESS: {
+      if (action.storedQueryState) {
+        return {
+          ...INITIAL_STATE,
+          ...action.storedQueryState,
+        };
+      }
+
+      return addNewQuery(state, action);
+    }
     case types.NEW_QUERY: {
       return addNewQuery(state, action);
     }
@@ -43,7 +52,8 @@ export default function (state = INITIAL_STATE, action) {
       }
 
       newState.queryIds.splice(index, 1);
-      delete newState.queriesById[state.currentQueryId];
+      newState.queriesById =
+        omit(newState.queriesById, state.currentQueryId);
 
       if (newState.queryIds.length >= 1) {
         return newState;

--- a/src/renderer/store/configure.js
+++ b/src/renderer/store/configure.js
@@ -24,7 +24,8 @@ if (isLogConsoleEnabled || isLogFileEnabled) {
     if (typeof console[method] === 'function') { // eslint-disable-line no-console
       loggerConfig.logger[method] = function levelFn(...args) {
         if (isLogConsoleEnabled) {
-          console[method].apply(console, args); // eslint-disable-line no-console
+          const m = method === 'debug' ? 'log' : method;
+          console[m].apply(console, args); // eslint-disable-line no-console
         }
 
         if (isLogFileEnabled) {

--- a/src/renderer/utils/getCurrentServerId.js
+++ b/src/renderer/utils/getCurrentServerId.js
@@ -1,0 +1,12 @@
+const getCurrentServerId = state => {
+  try {
+    const { servers: { items } } = state;
+    const currentServerId = state.connections.server.id;
+
+    return items.find(({ id }) => id === currentServerId).id;
+  } catch (err) {
+    return '';
+  }
+};
+
+export default getCurrentServerId;


### PR DESCRIPTION
In regards to issue #318

~~Currently in progress but looking for feedback -- Mostly done, just need to thoroughly test it.~~ Finished

I'm persisting `store.queries` by `serverId` in the `sqlectron.json` file on every action that updates queries, debounced by 500ms.

When selecting a server, upon successful connection I'm retrieving the stored data and dispatching an action to put it in the store if a stored query list exists.

~~Right now I have an odd bug in that if your last selected tab was any besides the first, and you log out then back in and select tab 1, it won't pop in the text for tab 1 until you click the editor pane. I don't know why, but if I can't figure that out.~~

~~I think I'm going to just default to tab 1 on every load, because if tab 1 is the initial tab it works fine.~~ Fixed it -- See below

In this PR I also made the `selectedQuery` value get passed into the actions -- my initial plan for implementation was going to have me updating only changed parts, but decided it was easier to just store an entire snapshot of the `queries` object from the store.

During this PR I somehow introduced a bug in the `REMOVE_QUERY` reducer, at the line where the removed query was being deleted from the `queriesById` object. I fixed that by bringing in `lodash.omit` and just omitting that key instead.

My thought here is that this was failing due to mutating the underlying data, as simply spreading state to make a copy only made a shallow 1-layer deep copy, so the `delete` command was trying to directly mutate data in the store (because `queries.queriesById` is only a pointer at this point, not a copied value) -- `_.omit()` returns a brand new object without mutating, and this is generally regarded as best practice.

Here's an example of a `sqlectron.json` file after this PR w/ 2 tabs open in my second db (note: these are the docker instances, so passwords aren't secure)

```{
  "servers": [
    {
      "id": "14455516-25b2-40f4-879a-02df23f8c168",
      "name": "docker-pg",
      "client": "postgresql",
      "ssl": false,
      "host": "192.168.99.100",
      "port": 5432,
      "socketPath": null,
      "user": "user",
      "password": "14488c2275e8fd79",
      "database": "company",
      "schema": null,
      "encrypted": true
    },
    {
      "id": "fe61b1a7-f815-4c26-95c4-bb628c67a606",
      "name": "docker-mysql",
      "client": "mysql",
      "ssl": false,
      "host": "192.168.99.100",
      "port": 3306,
      "socketPath": null,
      "user": "root",
      "password": "14488c2275e8fd79",
      "database": "authentication",
      "schema": null,
      "encrypted": true
    }
  ],
  "queries": {
    "fe61b1a7-f815-4c26-95c4-bb628c67a606": {
      "lastCreatedId": 3,
      "currentQueryId": 2,
      "queryIds": [
        1,
        2
      ],
      "queriesById": {
        "1": {
          "id": 1,
          "database": "authentication",
          "name": "authentication #1",
          "filename": null,
          "isExecuting": false,
          "isDefaultSelect": false,
          "didInvalidate": true,
          "query": "query 1",
          "selectedQuery": 1,
          "queryHistory": [],
          "results": null,
          "error": null,
          "copied": false,
          "resultItemsPerPage": 100
        },
        "2": {
          "id": 2,
          "database": "authentication",
          "name": "authentication #2",
          "filename": null,
          "isExecuting": false,
          "isDefaultSelect": false,
          "didInvalidate": true,
          "query": "query 2",
          "selectedQuery": 2,
          "queryHistory": [],
          "results": null,
          "error": null,
          "copied": false,
          "resultItemsPerPage": 100
        }
      },
      "resultItemsPerPage": 100,
      "enabledAutoComplete": true,
      "enabledLiveAutoComplete": true
    }
  }
}```