### PR TITLE
fixed the redux logger to include sub-items under action logs

### DIFF
--- a/src/renderer/store/configure.js
+++ b/src/renderer/store/configure.js
@@ -24,7 +24,8 @@ if (isLogConsoleEnabled || isLogFileEnabled) {
     if (typeof console[method] === 'function') { // eslint-disable-line no-console
       loggerConfig.logger[method] = function levelFn(...args) {
         if (isLogConsoleEnabled) {
-          console[method].apply(console, args); // eslint-disable-line no-console
+          const m = method === 'debug' ? 'log' : method;
+          console[m].apply(console, args); // eslint-disable-line no-console
         }
 
         if (isLogFileEnabled) {


### PR DESCRIPTION
Redux logger seems to need the initial action log to be a `console.log` and not a `console.debug`.

By changing it to a `console.log` you can get the dropdowns under the actions that show the before and after of the store, as well as the value of the action.

Before (you can see 3 of the items are expanded, but nothing appears):

<img width="362" alt="screen shot 2017-10-15 at 3 01 19 pm" src="https://user-images.githubusercontent.com/8228066/31588625-6bd72948-b1ba-11e7-887e-370a585be57c.png">

After:
<img width="807" alt="screen shot 2017-10-15 at 3 04 48 pm" src="https://user-images.githubusercontent.com/8228066/31588626-6bff4ca2-b1ba-11e7-9daa-13d9f0c71af6.png">

