### PR TITLE
Added checkbox to toggle wrapping in query editor (#298)

### DIFF
--- a/src/renderer/components/query.jsx
+++ b/src/renderer/components/query.jsx
@@ -6,6 +6,7 @@ import 'brace/mode/sql';
 import 'brace/theme/github';
 import 'brace/ext/language_tools';
 import 'brace/ext/searchbox';
+import CheckBox from './checkbox.jsx';
 import QueryResult from './query-result.jsx';
 import ServerDBClientInfoModal from './server-db-client-info-modal.jsx';
 
@@ -64,7 +65,9 @@ export default class Query extends Component {
 
   constructor(props, context) {
     super(props, context);
-    this.state = {};
+    this.state = {
+      wrapEnabled: false
+    };
   }
 
   componentDidMount() {
@@ -275,10 +278,11 @@ export default class Query extends Component {
               mode="sql"
               theme="github"
               name={this.props.editorName}
-              height="100%"
+              height="calc(100% - 15px)"
               width="100%"
               ref="queryBoxTextarea"
               value={query.query}
+              wrapEnabled={this.state.wrapEnabled}
               showPrintMargin={false}
               commands={this.getCommands()}
               editorProps={{ $blockScrolling: Infinity }}
@@ -286,6 +290,15 @@ export default class Query extends Component {
               enableBasicAutocompletion
               enableLiveAutocompletion
               />
+              <div className="ui secondary menu" style={{ marginTop: 0 }}>
+                <div className="right menu">
+                    <CheckBox
+                      name="wrapQueryContents"
+                      label="Wrap Contents"
+                      onChecked={() => { this.setState({ wrapEnabled: true }) }}
+                      onUnchecked={() => { this.setState({ wrapEnabled: false }) }}/>
+                </div>
+              </div>
           </ResizableBox>
           <div className="ui secondary menu" style={{ marginTop: 0 }}>
             {infos &&

--- a/src/renderer/components/query.jsx
+++ b/src/renderer/components/query.jsx
@@ -66,7 +66,7 @@ export default class Query extends Component {
   constructor(props, context) {
     super(props, context);
     this.state = {
-      wrapEnabled: false
+      wrapEnabled: false,
     };
   }
 
@@ -288,17 +288,16 @@ export default class Query extends Component {
               editorProps={{ $blockScrolling: Infinity }}
               onChange={debounce(onSQLChange, 50)}
               enableBasicAutocompletion
-              enableLiveAutocompletion
-              />
-              <div className="ui secondary menu" style={{ marginTop: 0 }}>
-                <div className="right menu">
-                    <CheckBox
-                      name="wrapQueryContents"
-                      label="Wrap Contents"
-                      onChecked={() => { this.setState({ wrapEnabled: true }) }}
-                      onUnchecked={() => { this.setState({ wrapEnabled: false }) }}/>
-                </div>
+              enableLiveAutocompletion />
+            <div className="ui secondary menu" style={{ marginTop: 0 }}>
+              <div className="right menu">
+                <CheckBox
+                  name="wrapQueryContents"
+                  label="Wrap Contents"
+                  onChecked={() => { this.setState({ wrapEnabled: true }); }}
+                  onUnchecked={() => { this.setState({ wrapEnabled: false }); }} />
               </div>
+            </div>
           </ResizableBox>
           <div className="ui secondary menu" style={{ marginTop: 0 }}>
             {infos &&

--- a/src/renderer/components/query.jsx
+++ b/src/renderer/components/query.jsx
@@ -173,6 +173,14 @@ export default class Query extends Component {
     this.refs.queryBoxTextarea.editor.resize();
   }
 
+  onWrapContentsChecked() {
+    this.setState({ wrapEnabled: true });
+  }
+
+  onWrapContentsUnchecked() {
+    this.setState({ wrapEnabled: false });
+  }
+
   getQueryCompletions(props) {
     const {
       databases,
@@ -294,8 +302,8 @@ export default class Query extends Component {
                 <CheckBox
                   name="wrapQueryContents"
                   label="Wrap Contents"
-                  onChecked={() => { this.setState({ wrapEnabled: true }); }}
-                  onUnchecked={() => { this.setState({ wrapEnabled: false }); }} />
+                  onChecked={::this.onWrapContentsChecked}
+                  onUnchecked={::this.onWrapContentsUnchecked} />
               </div>
             </div>
           </ResizableBox>


### PR DESCRIPTION
See the screenshot below.

I've added a toggle button that enables / disables wrapping in the query editor as per #298 so that it is no longer necessary to keep scrolling horizontally. 

I can gladly move this toggle elsewhere in the ui or put it a menu somewhere - I wasn't too sure about where it was supposed to be. 

Also, I did take into account the editor box resizing and tested to make ensure that didn't mess up the placement. 

![screenshot from 2017-10-18 00-15-31](https://user-images.githubusercontent.com/12233471/31700841-099ba6fa-b39a-11e7-98d1-f8058ec59ed0.png)

