### PR TITLE
Re-rendering QueryResult when sidebar width changes

### DIFF
--- a/src/renderer/components/query-result-table.jsx
+++ b/src/renderer/components/query-result-table.jsx
@@ -49,6 +49,15 @@ export default class QueryResultTable extends Component {
   componentWillReceiveProps(nextProps) {
     this.resize(nextProps);
 
+    if (nextProps.widthOffset !== this.props.widthOffset) {
+      if (this.rowsGrid) {
+        this.rowsGrid.recomputeGridSize();
+      }
+      if (this.headerGrid) {
+        this.headerGrid.recomputeGridSize();
+      }
+    }
+
     if (nextProps.copied) {
       this.setState({ showCopied: true });
     }

--- a/src/renderer/components/query-result.jsx
+++ b/src/renderer/components/query-result.jsx
@@ -30,7 +30,8 @@ export default class QueryResult extends Component {
     return (
       (!nextProps.isExecuting && this.props.isExecuting) ||
       (nextProps.query !== this.props.query) ||
-      (nextProps.copied && !this.props.copied)
+      (nextProps.copied && !this.props.copied) ||
+      (nextProps.widthOffset !== this.props.widthOffset)
     );
   }
 


### PR DESCRIPTION
Before this PR, re-sizing the sidebar doesn't cause QueryResult to re-render:

![before](https://user-images.githubusercontent.com/8228066/32476486-4a3fff1e-c33d-11e7-8735-d31df878709f.gif)

After this, it'll re-render when we stop dragging:

![after](https://user-images.githubusercontent.com/8228066/32476485-4a3208be-c33d-11e7-9c46-7ba1386d3f3f.gif)

I'm experimenting with ways to re-render as we drag but changing `query-browser`'s `onResizeStop` to `onResize` was really laggy. I tried debouncing it but it just didn't fire at that point until I stopped dragging.

Open to ideas, but in the mean time this small change is better than leaving it as is IMO.
