### PR TITLE
Fix Edit Button for RECENTLY DUPLICATED / NEW CONNECTIONS

### DIFF
--- a/src/renderer/actions/servers.js
+++ b/src/renderer/actions/servers.js
@@ -41,7 +41,7 @@ export function finishEditing() {
 }
 
 
-export function saveServer ({ server, id }) {
+export function saveServer ({ server, id }, onAfterSave) {
   return async (dispatch, getState) => {
     dispatch({ type: SAVE_SERVER_REQUEST, server });
     try {
@@ -54,6 +54,9 @@ export function saveServer ({ server, id }) {
         type: SAVE_SERVER_SUCCESS,
         server: convertToPlainObject(data),
       });
+
+
+      onAfterSave();
     } catch (error) {
       dispatch({ type: SAVE_SERVER_FAILURE, error });
     }
@@ -78,7 +81,7 @@ export function removeServer ({ id }) {
 }
 
 
-export function duplicateServer ({ server }) {
+export function duplicateServer ({ server }, onAfterSave) {
   return async (dispatch, getState) => {
     dispatch({ type: DUPLICATE_SERVER_REQUEST, server });
     try {
@@ -95,6 +98,9 @@ export function duplicateServer ({ server }) {
         type: DUPLICATE_SERVER_SUCCESS,
         server: convertToPlainObject(data),
       });
+
+
+      onAfterSave();
     } catch (error) {
       dispatch({ type: DUPLICATE_SERVER_FAILURE, error });
     }

--- a/src/renderer/containers/server-management.jsx
+++ b/src/renderer/containers/server-management.jsx
@@ -64,13 +64,19 @@ class ServerManagerment extends Component {
 
   onDuplicateClick(server) {
     const { dispatch } = this.props;
-    dispatch(ServersActions.duplicateServer({ server }));
+    const onAfterSave = () => {
+      dispatch(ConfigActions.loadConfig());
+    };
+    dispatch(ServersActions.duplicateServer({ server }, onAfterSave));
   }
 
   onSaveClick(server) {
     const { dispatch, servers } = this.props;
     const id = servers.editingServer && servers.editingServer.id;
-    dispatch(ServersActions.saveServer({ id, server }));
+    const onAfterSave = () => {
+      dispatch(ConfigActions.loadConfig());
+    };
+    dispatch(ServersActions.saveServer({ id, server }, onAfterSave));
   }
 
   onCancelClick() {


### PR DESCRIPTION
Refer to this issue for more details...
https://github.com/sqlectron/sqlectron-gui/issues/409

Below is a short description
Edit and Other commands don't work for RECENTLY DUPLICATED CONNECTIONS

1. duplicate an existing connection
2. try to edit it (notice it's not working)...

Connect button works, but the edit button doesn't work.

I'll check to see if I can send in a PR.