### PR TITLE
Change Zoom Factor Control to slider

### DIFF
--- a/src/renderer/components/settings-modal-form.jsx
+++ b/src/renderer/components/settings-modal-form.jsx
@@ -157,16 +157,22 @@ export default class SettingsModalForm extends Component {
 
   renderBasicSettingsPanel() {
     /* eslint max-len:0 */
+    const { zoomFactor } = this.state;
+    const zoomFactorLabel = `${Math.round(zoomFactor * 100)}%`;
+
     return (
       <div>
         <div className="two fields">
           <div className={`field ${this.highlightError('zoomFactor')}`}>
-            <label>Zoom Factor</label>
-            <input type="number"
+            <label>Zoom Factor: {zoomFactorLabel}</label>
+            <input type="range"
+              min="0.4"
+              max="2"
+              step="0.2"
               name="zoomFactor"
-              value={this.state.zoomFactor || ''}
-              onChange={::this.handleChange} />
-            <p className="help">Zoom factor is zoom percent divided by 100, so 300% = 3.0.</p>
+              value={zoomFactor}
+              onChange={::this.handleChange}
+              style={{ width: '100%', 'margin-top': '10px' }} />
           </div>
           <div className={`field ${this.highlightError('limitQueryDefaultSelectTop')}`}>
             <label>Limit of Rows from Select Top Query</label>


### PR DESCRIPTION
Fixes https://github.com/sqlectron/sqlectron-gui/issues/413

I decided to use HTML5 range control (no dependency) instead of third party Semantic UI library (lots of dependencies that needs to be imported for us to use it).

**Benefits:**
1. No need to do extra validation on the form
2. Look nicer and easier to use from users' perspective.

**Screenshot:**
![screen shot 2017-12-22 at 10 47 26 am](https://user-images.githubusercontent.com/3792401/34309203-b933543e-e705-11e7-85b8-97157849657c.png)

