### PR TITLE
Reveal previous saved password in the connections.

### DIFF
--- a/src/renderer/components/server-modal-form.jsx
+++ b/src/renderer/components/server-modal-form.jsx
@@ -40,6 +40,7 @@ export default class ServerModalForm extends Component {
     this.state = {
       ...server,
       isNew: !server.id,
+      showPlainPassword: false,
     };
   }
 
@@ -91,6 +92,10 @@ export default class ServerModalForm extends Component {
 
   onDuplicateClick() {
     this.props.onDuplicateClick(this.mapStateToServer(this.state));
+  }
+
+  onToggleShowPlainPasswordClick() {
+    this.setState({ showPlainPassword: !this.state.showPlainPassword });
   }
 
   isFeatureDisabled(feature) {
@@ -333,13 +338,21 @@ export default class ServerModalForm extends Component {
               onChange={::this.handleChange} />
           </div>
           <div className={`four wide field ${this.highlightError('password')}`}>
-            <label>Password</label>
-            <input type="password"
-              name="password"
-              placeholder="Password"
-              value={this.state.password || ''}
-              disabled={this.isFeatureDisabled('server:password')}
-              onChange={::this.handleChange} />
+            <div>
+              <label>Password</label>
+            </div>
+            <div className="ui action input">
+              <input type={this.state.showPlainPassword ? 'text' : 'password'}
+                name="password"
+                placeholder="Password"
+                value={this.state.password || ''}
+                disabled={this.isFeatureDisabled('server:password')}
+                onChange={::this.handleChange} />
+              <span className="ui icon button"
+                onClick={::this.onToggleShowPlainPasswordClick}>
+                <i className="unhide icon"></i>
+              </span>
+            </div>
           </div>
           <div className={`four wide field ${this.highlightError('database')}`}>
             <label>Initial Database/Keyspace</label>


### PR DESCRIPTION
Password reveal, fixes #398

Give users an ability to show previously saved passwords.

![screen shot 2017-12-22 at 1 41 38 pm](https://user-images.githubusercontent.com/3792401/34313114-d91ba3ce-e71d-11e7-84a9-25939ac4ad31.png)

![screen shot 2017-12-22 at 1 41 40 pm](https://user-images.githubusercontent.com/3792401/34313115-da19a6c2-e71d-11e7-918c-4a576365fa95.png)
