### PR TITLE
[WIP] Add support for snapcraft

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
       "target": [
         "deb",
         "rpm",
-        "snap",
         "sh",
         "freebsd",
         "pacman",
@@ -52,6 +51,15 @@
         "nsis",
         "7z",
         "zip"
+      ]
+    }
+  },
+  "build-snap": {
+    "appId": "org.sqlectron.gui",
+    "linux": {
+      "depends": [],
+      "target": [
+        "snap"
       ]
     }
   },

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
       "target": [
         "deb",
         "rpm",
+        "snap",
         "sh",
         "freebsd",
         "pacman",
@@ -106,7 +107,7 @@
     "del": "^2.2.0",
     "denodeify": "^1.2.1",
     "electron": "^1.7.9",
-    "electron-builder": "^11.7.0",
+    "electron-builder": "^19.53.0",
     "eslint": "^2.13.1",
     "eslint-config-airbnb": "^9.0.1",
     "eslint-config-airbnb-base": "^3.0.1",


### PR DESCRIPTION
I've put together this pull request to add a [snap](https://snapcraft.io) package. I've tested it on Ubuntu 16.04 and 17.10, but it should work just as well on Ubuntu 14.04, Linux Mint, Manjaro, Debian, OpenSUSE, Solus, etc.

If you merge and `npm run build-snap` on an Ubuntu 16.04 VM with an [appropriate version of node installed](https://github.com/nodesource/distributions) it will create `dist/sqlectron_VERSION_amd64.snap`.

Copy this to a Linux system, [enable snap support](https://docs.snapcraft.io/core/install), then run:
`sudo snap install --dangerous sqlectron_VERSION_amd64.snap`. Execute it with `sqlectron` from the terminal or find it in the desktop launcher.

If you create a developer account and push this to the Snap Store, it can be discovered and installed through GNOME Software and https://snapcraft.io/discover. To create the developer account, [sign up here](https://dashboard.snapcraft.io/dev/account/), then [register the "sqlectron" name](https://dashboard.snapcraft.io/register-snap/?name=sqlectron).

You'll need the `snapcraft` command to push the snap file to the store.
* If you're on a Mac, you can `brew install snapcraft`
* If you're on Linux, it's `sudo snap install --classic snapcraft`

Then you can push it to the store out with:
`snapcraft push sqlectron_VERSION_amd64.snap --release stable`