### PR TITLE
fix: upgrade jquery to 3.3 to avoid security issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "html2canvas": "^0.5.0-beta4",
     "imports-loader": "^0.6.5",
     "jointjs": "^0.9.9",
-    "jquery": "^2.2.0",
+    "jquery": "^3.3.1",
     "json-loader": "^0.5.4",
     "lodash.bindall": "^4.4.0",
     "lodash.clonedeep": "^4.5.0",


### PR DESCRIPTION
Let's just upgrade jquery to avoid security issue/warning :)

everything seems to still works after this.