### PR TITLE
Fixes #469 - query results error out if no custom font is set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ addons:
     - bsdtar
 install:
 - clang --version
-- nvm install 6
+- nvm install 8
 - npm prune
 - npm install
 script:

--- a/src/renderer/components/query-result-table.jsx
+++ b/src/renderer/components/query-result-table.jsx
@@ -337,7 +337,7 @@ export default class QueryResultTable extends Component {
    */
   resolveCellWidth(fieldName, fields, rows) {
     const customFont = this.props.config.data.customFont || 'Helvetica Neue';
-    const font = `14px '${customFont}' 'Helvetica Neue', Arial, Helvetica, sans-serif`;
+    const font = `14px '${customFont}', 'Helvetica Neue', Arial, Helvetica, sans-serif`;
     const numRowsToFindAverage = rows.length > 30 ? 30 : rows.length;
     const maxWidth = 220;
     const headerWidth = this.getTextWidth(fieldName, `bold ${font}`);

--- a/src/renderer/components/query-result-table.jsx
+++ b/src/renderer/components/query-result-table.jsx
@@ -336,13 +336,11 @@ export default class QueryResultTable extends Component {
    * It gives a better UX since the column adapts better to the table width.
    */
   resolveCellWidth(fieldName, fields, rows) {
-    const { customFont } = this.props.config.data.customFont;
-    const font = `14px '${customFont}', 'Helvetica Neue', Arial, Helvetica, sans-serif`;
+    const customFont = this.props.config.data.customFont || 'Helvetica Neue';
+    const font = `14px '${customFont}' 'Helvetica Neue', Arial, Helvetica, sans-serif`;
     const numRowsToFindAverage = rows.length > 30 ? 30 : rows.length;
     const maxWidth = 220;
-
     const headerWidth = this.getTextWidth(fieldName, `bold ${font}`);
-
     let averageRowsCellWidth = 0;
     if (rows.length) {
       averageRowsCellWidth = rows

--- a/src/renderer/containers/app.jsx
+++ b/src/renderer/containers/app.jsx
@@ -107,7 +107,7 @@ class AppContainer extends Component {
     let style = null;
 
     if (config.isLoaded) {
-      const customFont = config.data.customFont;
+      const customFont = config.data.customFont || 'Helvetica Neue';
       style = { fontFamily: `'${customFont}', 'Helvetica Neue', Arial, Helvetica, sans-serif` };
     }
 


### PR DESCRIPTION
- if no custom font has been set from the settings modal you are unable to see query results
- this fixes the issue by defaulting the custom font to the default font

Fixes #469 