### PR TITLE
bump sqlectron-core to ^8.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "babel-polyfill": "^6.22.0",
     "bunyan": "^1.8.5",
     "lodash.defaultsdeep": "^4.6.0",
-    "sqlectron-core": "^8.0.0"
+    "sqlectron-core": "^8.1.0"
   },
   "devDependencies": {
     "autoprefixer-loader": "^3.2.0",


### PR DESCRIPTION
Updates sqlectron-core to ^8.1.0. It's changelog:

> ## Features
>
>* Add cassandra authentication support
>* Support MySQL caching_sha2_password authentication (default for MySQL 8)
>* Use os.homedir to find user home directory (instead of hand-rolled implementation)
>* Add function to database clients to get version of currently connected client
>* Replace usage of deprecated createCipher / createDecipher with createCipheriv / createDecipheriv
>* Add official support for MySQL 8 and Postgresql 12
>* Add official support for cassandra 2.x and 3.10+
>* Add official support for MariaDB 10.1+
>* Add official support for Node 10 and 12 for sqlectron-core
>
>## Fixes
>
>* Fix querying information_schema table on MySQL 8 returning results in different casing than prior versions
>* Fix not being able to specify socket without a port
>* Use ordinal_position to order column listing in postgresql, sqlserver, and mysql instead of relying on row ordering
>* Fix truncateAllTables for sqlserver not first disabling foreign key constraints
>* Fix client validator not properly rejecting invalid clients
>* Fix sqlserver client breaking if using a CS collation
>
>## Dependencies
>
>* Update mkdirp to ^0.5.2 (security)
>* Move from mysql to mysql2 (better support for mysql 8)
>* Update pg to ^7.18.0
>* Update sqlite3 to ^4.0.6
>* Move from valida to valida2
>* Update babel to ^7.8.4
>* Update eslint to ^4.19.1
>* Update chai to ^4.2.0
>* Update babel-eslint to ^10.1.0
>* Update eslint-config-airbnb-base to ^11.3.2
>* Update mocha to ^6.2.3
>* Add nyc to get test coverage
>* Update sinon to ^7.5.0
>
>## Chores
>
>* Replace appveyor with GitHub actions
>* Add automated testing for cassandra

Closes #458
Closes #444
Closes #442