### PR TITLE
Update travis build configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ addons:
     - bsdtar
 install:
 - clang --version
-- nvm install 6
+- nvm install 8
 - npm prune
 - npm install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,7 @@ cache:
   - node_modules
   - app/node_modules
   - $HOME/.electron
-env:
-  global:
-  # GH_TOKEN
-  - secure: EpeYT6T82lfJrnQn9QwHDxLRx9iT30yQp8NHIs+rH0T7Yxegm6YRHYr8nLOen/Ny+Kyq9qNeW6D3kelkWsfMADXIQKh7n/vSjXb535+iQeMOUSVQu8PKFzkwDLJIbYKRugVZJ2k+nqsBPqbiG5RiV71ztWgxz4GN28nLnJIYhiCA2yCilITS/WcreHUSAjFUWubQQTCptFHTYTvNKxclw9eps6vwPM0/+KSnbM5SD5O14ZtjairSwj72+RjT3WveAznD2nzqjroKd1r2JZPrRIrQUCj8tKJHilYzWW91IgH9FYJKHjO3VSjv1JiiJrO8LTmur9lArbYBA9pJvbCmg7iXYFUAHMlbKs/yRrIwiMOuKvEX6Mw43YG4zz2X+F5oH1tis8+b1kfehL44gfCNEJtfpJRHEvfafm4WZumar0aZV4xVUYkbYuRj07X/+/kn7Zy9M+obZbVaajh3irCSw79ApSZ0lRciYgVbGE7dHsx6u9CKFKOInONowU2koPkfgTneslmbYpyfRUPQTytYkzfjBFOYj3RFd7ruYr+qdt7ouusKjZmRgO6fNNG8+hYynb/grX8di9sxBSXIuh29EFVNY8uXBVKpyMcJ9AN4TZ/PCMjCfPYxMIyPx9YGE2tTalhuQf1YXT8n72MZGW+7DMWdiGBZzHPZJw2tH9oEtU4=
+
 addons:
   apt:
     sources:


### PR DESCRIPTION
It looks like there's been an unintended change in a transitive dependency that is causing Travis to break due to usage of `async function`. Support for this was added in Node 7+, and so this updates things to the next LTS release after that, node 8, attempting to keep the node version from changing as much as possible for the next release.

The GH_TOKEN that is defined in the travis.yml file is no longer valid either it seems, so it was removed. A new GH_TOKEN will be defined using the Travis-CI secrets system.