### PR TITLE
Update appveyor build configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ cache:
 
 environment:
   GH_TOKEN:
-    secure: b2OJ5cBogX2ABZkue3un76SwbmFuJmy0zTC8WMW9eaUARWQCGBQSoQzP6ilwbm2r
+    secure: Mcr1WaCcl8T8zMHQONttCUUyYfd4jtEnMjnWlE7vCzBf6tqq+X3LHPMzSWSw+UTU
 
 init:
   - git config --global core.autocrlf input

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ init:
   - git config --global core.autocrlf input
 
 install:
-  - ps: Install-Product node 6 x64
+  - ps: Install-Product node 8 x64
   - git reset --hard HEAD
   - npm install npm@4 -g
   - npm prune


### PR DESCRIPTION
The currently set token is no longer valid, which causes a HTTP 401 error to be thrown when electron-builder goes to look up release information. This PR replaces it with a new, valid token.

Additionally, similar to #485, this updates the build environment to use Node 8 due to a transitive dependency using the `async function` syntax which was supported in Node 7+. Given that Node 6 EOL was years ago and is supported in Ubuntu 18.04, this should be fine.