### PR TITLE
add upload artifact step to gh build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,3 +40,9 @@ jobs:
     - run: npm test
 
     - run: npm run dist -- --publish never
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v1
+      with:
+        name: ${{ matrix.os }}
+        path: dist


### PR DESCRIPTION
So that it will be possible to download the artifacts from GH to test in-progress work, without necessarily having to build it locally as well.

A future step would be to create an individualized list of files to upload and so could download a specific artifact for a given architecture / os, but that can come later in an iteration on this after electron-builder is further upgraded in a future version.