### PR TITLE
Add note about libgconf to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@
 * [Terminal](https://github.com/sqlectron/sqlectron-term) - A terminal-based interface of Sqlectron.
 * [Contribute](CONTRIBUTING.md) - Details on how you can contribute to Sqlectron.
 
+__Note__: For Linux users, to use Sqlectron, you will need to install `libgconf` or else the program will crash. To install this dependency, it's usually available via
+package manager as either libgconf-2-4 or gconf2.
+
 #### How to pronounce
 
 It is pronounced "sequel-eck-tron" - https://translate.google.com/?source=osdd#en/en/sequel-eck-tron


### PR DESCRIPTION
Adds a note about issue pointed out in #449. While it would be better to resolve this issue in a way that's transparent to users, my VM does not work and figuring this out would probably be better spent just upgrading electron version instead.