### PR TITLE
Update electron-builder publish type to released from draft

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,10 @@
         "7z",
         "zip"
       ]
+    },
+    "publish": {
+      "provider": "github",
+      "releaseType": "release"
     }
   },
   "scripts": {


### PR DESCRIPTION
The electron-builder by default only functions on draft releases. However, GH actions only operates on published releases. As such, need to add this configuration to allow electron-builder to update existing publishes with release artifacts.