### PR TITLE
bump minimum version of node to 10.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      node-version: 8.x
+      node-version: 10.x
 
     strategy:
       matrix:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      node-version: 8.x
+      node-version: 10.x
 
     strategy:
       matrix:

--- a/docs/development/run-from-source.md
+++ b/docs/development/run-from-source.md
@@ -1,6 +1,6 @@
 # Run from Source
 
-The Sqlectron developer environment requires Node **(6 or higher)** and NPM.
+The Sqlectron developer environment requires Node **(10 or higher)** and NPM.
 
 **Cloning this project:**
 


### PR DESCRIPTION
This bumps sqlectron to require >= 10.x to develop. This is principally to make it easier to bring in the latest versions of various dependencies which for the most part require a minimum of 10.x (e.g. like the various webpack loaders). It's been out in the wild as the LTS release for ~2 years that it's safe to assume people will minimally have this version available.