### PR TITLE
bump version of react-select

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "react-redux": "^4.0.1",
     "react-resizable": "^1.4.2",
     "react-router": "^2.8.1",
-    "react-select": "^0.9.1",
+    "react-select": "^1.3.0",
     "react-tabs": "git+https://github.com/maxcnunes/react-tabs.git#remove-warnings",
     "react-transform-hmr": "^1.0.1",
     "react-virtualized": "^7.3.1",


### PR DESCRIPTION
This version of react-select had an incompatible peerDependency on the version of react used by sqlectron. Upgrading does not cause any issues that did not already exist in the project (see #504).