### PR TITLE
explicitly mark binary files in gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,12 @@
 * text eol=lf
+
+# Binary files.
+*.gif binary
+*.png binary
+*.jpg binary
+*.woff binary
+*.woff2 binary
+*.eot binary
+*.otf binary
+*.ttf binary
+*.icns binary


### PR DESCRIPTION
Marking these files as binary files in the `.gitattributes` so that they don't get potentially messed up on windows with its wacky git crlf settings.