### PR TITLE
fix quotation style in npm run script for windows usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "scripts": {
     "postinstall": "electron-builder install-app-deps",
-    "dev": "concurrently --names 'webpack,electron' --prefix name 'npm run dev:webpack' 'npm run dev:electron'",
+    "dev": "concurrently --names \"webpack,electron\" --prefix name \"npm run dev:webpack\" \"npm run dev:electron\"",
     "dev:webpack": "webpack-dev-server --color --config ./webpack.dev.config.js",
     "dev:electron": "cross-env DEBUG=spawn-auto-restart node scripts/dev-auto-restart.js | bunyan -o short",
     "lint": "eslint . --ext .js,.jsx",


### PR DESCRIPTION
Before this change, got this error when running the `dev` script on Windows:

```
E:\Github\sqlectron-gui>npm run dev

> sqlectron@1.31.0 dev E:\Github\sqlectron-gui
> concurrently --names 'webpack,electron' --prefix name 'npm run dev:webpack' 'npm run dev:electron'

['webpack] 'np' is not recognized as an internal or external command,
['webpack] operable program or batch file.
[electron'] 'run' is not recognized as an internal or external command,
[electron'] operable program or batch file.
[] The filename, directory name, or volume label syntax is incorrect.
[] 'np' is not recognized as an internal or external command,
[] operable program or batch file.
[] 'run' is not recognized as an internal or external command,
[] operable program or batch file.
[] The filename, directory name, or volume label syntax is incorrect.
[] run exited with code 1
[] np exited with code 1
[] dev:webpack' exited with code 1
[electron'] run exited with code 1
['webpack] np exited with code 1
[] dev:electron' exited with code 1
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! sqlectron@1.31.0 dev: `concurrently --names 'webpack,electron' --prefix name 'npm run dev:webpack' 'npm run dev:electron'`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the sqlectron@1.31.0 dev script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\mpeveler\AppData\Roaming\npm-cache\_logs\2020-08-25T23_08_37_933Z-debug.log
```