### PR TITLE
Pin version of sqlectron-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "bunyan": "^1.8.5",
     "core-js": "^3.6.5",
     "lodash.defaultsdeep": "^4.6.0",
-    "sqlectron-core": "^8.1.1"
+    "sqlectron-core": "8.1.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",


### PR DESCRIPTION
Using the caret here has brought in changes with redshift that break the GUI. This module (and probably all dependencies) has been pinned for now to prevent that break.