### PR TITLE
pin version of electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "del": "^2.2.0",
     "denodeify": "^1.2.1",
     "dom-helpers": "^5.1.4",
-    "electron": "^8.4.1",
+    "electron": "8.2.5",
     "electron-builder": "^22.8.0",
     "eslint": "^4.19.1",
     "eslint-config-airbnb": "^17.1.1",


### PR DESCRIPTION
`sqlite3` only has pre-built binaries up to 8.2 line. There's not really anything necessary in the later versions of the 8.x line to necessitate upgrading further until ready to move to sqlite3 5.