### PR TITLE
fix react style key to be camelcase

### DIFF
--- a/src/renderer/components/settings-modal-form.jsx
+++ b/src/renderer/components/settings-modal-form.jsx
@@ -188,7 +188,7 @@ export default class SettingsModalForm extends Component {
               name="zoomFactor"
               value={zoomFactor}
               onChange={this.handleChange}
-              style={{ width: '100%', 'margin-top': '10px' }} />
+              style={{ width: '100%', marginTop: '10px' }} />
           </div>
           <div className={`field ${this.highlightError('limitQueryDefaultSelectTop')}`}>
             <label>Limit of Rows from Select Top Query</label>


### PR DESCRIPTION
This fixes `margin-top` to be `marginTop`, and get rid of react warning about it.