### PR TITLE
fix zoomFactor showing NaN on first start

### DIFF
--- a/src/renderer/components/settings-modal-form.jsx
+++ b/src/renderer/components/settings-modal-form.jsx
@@ -170,7 +170,7 @@ export default class SettingsModalForm extends Component {
 
   renderBasicSettingsPanel() {
     /* eslint max-len:0 */
-    const { zoomFactor } = this.state;
+    const zoomFactor = this.state.zoomFactor || 1;
     const zoomFactorLabel = `${Math.round(Number.parseFloat(zoomFactor) * 100)}%`;
 
     return (


### PR DESCRIPTION
This is a further continuation of the fix started in #457. The problem stems from that on first start, the zoom factor does not exist within the config.json file, and so would have `parseFloat(undefined)`, which then causes the `NaN` label.

This better guards the render to ensure the value is set to some numerical value if it's not set, so that the `NaN` will not happen, unless someone manually tampers with the file and breaks things.

The form itself has a minimum of `0.4` so we can take this simplistic `||` check and not worry about the conversion of the `0 || 1` case.