### PR TITLE
add keyboard/menu-bar zoom controls

### DIFF
--- a/src/browser/menu/darwin.js
+++ b/src/browser/menu/darwin.js
@@ -153,6 +153,24 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
           accelerator: 'Alt+Cmd+I',
           click: (item, win) => win.toggleDevTools(),
         },
+        {
+          type: 'separator',
+        },
+        {
+          label: 'Zoom In',
+          accelerator: 'Cmd+=',
+          role: 'zoomin',
+        },
+        {
+          label: 'Zoom Out',
+          accelerator: 'Cmd+-',
+          role: 'zoomout',
+        },
+        {
+          label: 'Reset Zoom',
+          accelerator: 'Cmd+0',
+          role: 'resetzoom',
+        },
       ],
     },
     {

--- a/src/browser/menu/linux.js
+++ b/src/browser/menu/linux.js
@@ -121,6 +121,24 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
           accelerator: 'Alt+Ctrl+I',
           click: (item, win) => win.toggleDevTools(),
         },
+        {
+          type: 'separator',
+        },
+        {
+          label: 'Zoom In',
+          accelerator: 'Ctrl+=',
+          role: 'zoomin',
+        },
+        {
+          label: 'Zoom Out',
+          accelerator: 'Ctrl+-',
+          role: 'zoomout',
+        },
+        {
+          label: 'Reset Zoom',
+          accelerator: 'Ctrl+0',
+          role: 'resetzoom',
+        },
       ],
     },
     {

--- a/src/browser/menu/win32.js
+++ b/src/browser/menu/win32.js
@@ -121,6 +121,24 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
           accelerator: 'Alt+Ctrl+I',
           click: (item, win) => win.toggleDevTools(),
         },
+        {
+          type: 'separator',
+        },
+        {
+          label: 'Zoom In',
+          accelerator: 'Ctrl+=',
+          role: 'zoomin',
+        },
+        {
+          label: 'Zoom Out',
+          accelerator: 'Ctrl+-',
+          role: 'zoomout',
+        },
+        {
+          label: 'Reset Zoom',
+          accelerator: 'Ctrl+0',
+          role: 'resetzoom',
+        },
       ],
     },
     {


### PR DESCRIPTION
It's a feature I need on my small laptop, where I often zoom in to make text more readable.

Tested on Linux (NixOS) running Electron 8.