### PR TITLE
fix query results not re-rendering if field information did not change

### DIFF
--- a/src/renderer/components/query-result-table.jsx
+++ b/src/renderer/components/query-result-table.jsx
@@ -291,7 +291,7 @@ export default class QueryResultTable extends Component {
   }
 
   renderTableBody(onScroll) {
-    const { rowCount, fields } = this.props;
+    const { rowCount, fields, rows } = this.props;
     const { tableWidth, tableHeight } = this.state;
 
     const headerHeight = 62; // value of 2 headers together
@@ -311,9 +311,10 @@ export default class QueryResultTable extends Component {
         rowCount={rowCount}
         columnCount={fields.length}
         columnWidth={this.getColumnWidth}
+        rows={rows}
         rowsCount={rowCount}
-        noContentRenderer={this.renderNoRows} />
-
+        noContentRenderer={this.renderNoRows}
+      />
     );
   }
 


### PR DESCRIPTION
closes #447

This query result code has a bug where if you run a query that does not change the shape of the returned results (fields, etc.), the query results table would in-turn not re-render as the child `<Grid>` object did not use the actual row values as prop value. 