### PR TITLE
fix opening select boxes changing modal top location

### DIFF
--- a/vendor/renderer/semantic-ui/README.md
+++ b/vendor/renderer/semantic-ui/README.md
@@ -1,9 +1,22 @@
 # customized semantic-ui
 
+Sqlectron uses a slightly modified version of semantic-ui. These edits are relatively minor,
+and allow it to play nicely with the react / local modal.
+
+Any changes can be easily found by searching for `>>> SQLECTRON CHANGE`. The edits are specifically
+listed below:
+
+**IMPORTANT** In case of editing semantic-ui to bring in a new version (or otherwise), these changes
+will have to be re-applied!
+
+## JS
+
+The semantic-ui js has some customizations:
+
+- observeChanges method ignores changes for "Select" class
+
+## CSS
+
 This semantic-ui css has some customizations:
 
 - Commented import of Lato fonts from Google because we use local fonts.
-
-**Important**
-
-In case updating semantic-ui this same changes should be applied again in the new file.

--- a/vendor/renderer/semantic-ui/semantic.js
+++ b/vendor/renderer/semantic-ui/semantic.js
@@ -8372,6 +8372,23 @@ $.fn.modal = function(parameters) {
         observeChanges: function() {
           if('MutationObserver' in window) {
             observer = new MutationObserver(function(mutations) {
+              /*
+                >>> SQLECTRON CHANGE: disable refreshing if changed element is "Select" class
+                The "Select" class is coming from React, and with how it functions, it injects
+                a component when the select is "opened". However, this triggers this function
+                with a DOM tree modified, and it attempts to "refresh" the modal, however, this
+                just messes up the `top` CSS for the modal with no benefit, so just ignore
+                refreshing instead.
+              */
+              if (
+                mutations
+                && mutations[0]
+                && mutations[0].target
+                && mutations[0].target.classList
+                && mutations[0].target.classList.contains('Select')
+              ) {
+                return;
+              }
               module.debug('DOM tree modified, refreshing');
               module.refresh();
             });


### PR DESCRIPTION
closes #504 

Opening / closing a select dropdown (such as in the Settings window to adjust log level) would cause the modal window to be redrawn with its `top` css element changed to now point to wherever the user was scrolled on the page. This would generally mess up trying to use the select box (especially if it was off-screen), and mess up the modal generally. This was happening because the modal window was using semantic-ui for styling, and built into it was a method to watch for mutations to the DOM tree and refresh the modals on change. However, this conflicts with the React design where components were being added/removed in the DOM tree for the select window, which was triggering the refreshes.

Semantic-UI has been adjusted so that it will no longer refresh itself on DOM changes that are properly our `Select` component (based off the `Select` class name. Clicking through the rest of the modals seems to show that no other fields had this problem.