### PR TITLE
upgrade to react-tabs to ^2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7573,12 +7573,6 @@
       "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==",
       "dev": true
     },
-    "js-stylesheet": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/js-stylesheet/-/js-stylesheet-0.0.1.tgz",
-      "integrity": "sha1-EswUUSIORUGEtG3jsJjA0VR2LDg=",
-      "dev": true
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -10272,12 +10266,13 @@
       }
     },
     "react-tabs": {
-      "version": "git+https://github.com/maxcnunes/react-tabs.git#101f334395dd4995d882ad32f52e1fbc7abb47da",
-      "from": "git+https://github.com/maxcnunes/react-tabs.git#remove-warnings",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-2.3.1.tgz",
+      "integrity": "sha512-SIT1Yx2LY5uwQQsCTQ9hXhywNKqyBdGBAzFZvzYUisztVwOWzfNWjZ7QWNOvuayT5/AF0RAHNbRedur8Yiz2pA==",
       "dev": true,
       "requires": {
         "classnames": "^2.2.0",
-        "js-stylesheet": "^0.0.1"
+        "prop-types": "^15.5.0"
       }
     },
     "react-virtualized": {

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "react-resizable": "^1.11.0",
     "react-router": "^2.8.1",
     "react-select": "^1.3.0",
-    "react-tabs": "git+https://github.com/maxcnunes/react-tabs.git#remove-warnings",
+    "react-tabs": "^2.3.1",
     "react-virtualized": "^7.3.1",
     "redux": "^3.5.0",
     "redux-logger": "^2.2.1",

--- a/src/renderer/components/react-tabs.scss
+++ b/src/renderer/components/react-tabs.scss
@@ -1,15 +1,22 @@
-
-.ReactTabs.react-tabs {
+.react-tabs {
   width: 100%;
   position: relative;
 }
 
-.ReactTabs.react-tabs .ReactTabs__TabList {
+.react-tabs .react-tabs__tab-list {
   white-space: nowrap;
 }
 
-.ReactTabs.react-tabs .ReactTabs__TabList .ReactTabs__Tab {
+.react-tabs ul.react-tabs__tab-list > li.react-tabs__tab.item {
   display: inline-block;
+}
+
+.react-tabs__tab-panel {
+  display: none;
+}
+
+.react-tabs__tab-panel--selected {
+  display: block;
 }
 
 #tabs-nav-wrapper {

--- a/src/renderer/containers/query-browser.jsx
+++ b/src/renderer/containers/query-browser.jsx
@@ -507,7 +507,7 @@ class QueryBrowserContainer extends Component {
       return (
         <Tab key={queryId}
           onDoubleClick={() => this.onTabDoubleClick(queryId)}
-          className={`item ${isCurrentQuery ? 'active' : ''}`}>
+          className={['react-tabs__tab', `item ${isCurrentQuery ? 'active' : ''}`]}>
           {buildContent()}
         </Tab>
       );
@@ -522,7 +522,7 @@ class QueryBrowserContainer extends Component {
       const query = queries.queriesById[queryId];
 
       return (
-        <TabPanel key={queryId}>
+        <TabPanel key={queryId} className={['react-tabs__tab-panel']}>
           <Query
             ref={`queryBox_${queryId}`}
             editorName={`querybox${queryId}`}
@@ -559,7 +559,7 @@ class QueryBrowserContainer extends Component {
     const selectedIndex = queries.queryIds.indexOf(queries.currentQueryId);
     const isTabsFitOnScreen = this.tabListTotalWidthChildren >= this.tabListTotalWidth;
     return (
-      <Tabs onSelect={this.handleSelectTab} selectedIndex={selectedIndex} forceRenderTabPanel>
+      <Tabs className={['react-tabs']} onSelect={this.handleSelectTab} selectedIndex={selectedIndex} forceRenderTabPanel>
         <div id="tabs-nav-wrapper" className="ui pointing secondary menu">
           {isTabsFitOnScreen
             && (
@@ -575,6 +575,7 @@ class QueryBrowserContainer extends Component {
           }
           <div className="tabs-container">
             <TabList
+              className={['react-tabs__tab-list']}
               ref="tabList"
               style={{ left: `${this.state.tabNavPosition}px`, transition: 'left 0.2s linear' }}>
               {menu}


### PR DESCRIPTION
Relevant release notes: 

* https://github.com/reactjs/react-tabs/releases/tag/v1.0.0
* https://github.com/reactjs/react-tabs/releases/tag/v2.0.0

The main change was in how classes were now named, and how they were not given automatically. The extra specificity for `react-tabs__tab` was to make sure it took precedence over semantic.css.

Tested for #311 which was the foundation of using the fork, and it remains fixed here, with all tabs remaining usable.