### PR TITLE
fix the open/save query functionality

### DIFF
--- a/src/renderer/utils/file-handler.js
+++ b/src/renderer/utils/file-handler.js
@@ -6,12 +6,13 @@ export function showSaveDialog(filters) {
   return new Promise((resolve, reject) => {
     remote.dialog.showSaveDialog({
       filters,
-    }, (fileName) => {
-      if (fileName) {
-        return resolve(fileName);
+    }).then((dialogObject) => {
+      if (dialogObject.canceled) {
+        return reject();
       }
-
-      return reject();
+      return resolve(dialogObject.filePath);
+    }).catch((err) => {
+      reject(err);
     });
   });
 }
@@ -33,12 +34,13 @@ export function showOpenDialog(filters, defaultPath) {
       defaultPath,
       filters,
       properties: ['openFile'],
-    }, (fileName) => {
-      if (fileName) {
-        return resolve(fileName);
+    }).then((dialogObject) => {
+      if (dialogObject.canceled || dialogObject.filePaths.length === 0) {
+        return reject();
       }
-
-      return reject();
+      return resolve(dialogObject.filePaths);
+    }).catch((err) => {
+      reject(err);
     });
   });
 }


### PR DESCRIPTION
Closes #540 

This broke in the move to electron 8.2.5 where electron 6 changed the signature of this function to have a callback to instead use a promise interface. This modifies the show(Save|Open)Dialog functions to now utilize that promise, while still wrapping the result into the same form as was being used before where the `resolve` is given the singular filename (if there is one) while it rejects in cases where no file is selected (due to canceling) or we hit an error case.