### PR TITLE
upgrade react-router to ^3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlectron",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6560,35 +6560,15 @@
       "dev": true
     },
     "history": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/history/-/history-2.1.2.tgz",
-      "integrity": "sha1-SqLeiXoOSGfkU5hDvm7Nsphr/ew=",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-3.3.0.tgz",
+      "integrity": "sha1-/O3M6PEpdTcVRdc1RhAzV5ptrpw=",
       "dev": true,
       "requires": {
-        "deep-equal": "^1.0.0",
-        "invariant": "^2.0.0",
-        "query-string": "^3.0.0",
-        "warning": "^2.0.0"
-      },
-      "dependencies": {
-        "query-string": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/query-string/-/query-string-3.0.3.tgz",
-          "integrity": "sha1-ri4UtNBQcdTpuetIc8NbDc1C5jg=",
-          "dev": true,
-          "requires": {
-            "strict-uri-encode": "^1.0.0"
-          }
-        },
-        "warning": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz",
-          "integrity": "sha1-ISINnGOvx3qMkhEeARr3Bc4MaQE=",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        }
+        "invariant": "^2.2.1",
+        "loose-envify": "^1.2.0",
+        "query-string": "^4.2.2",
+        "warning": "^3.0.0"
       }
     },
     "hmac-drbg": {
@@ -10171,24 +10151,19 @@
       }
     },
     "react-router": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-2.8.1.tgz",
-      "integrity": "sha1-c+lJH2zrMW0Pd5gpCBhj43juTtc=",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-3.2.6.tgz",
+      "integrity": "sha512-nlxtQE8B22hb/JxdaslI1tfZacxFU8x8BJryXOnR2RxB4vc01zuHYAHAIgmBkdk1kzXaA25hZxK6KAH/+CXArw==",
       "dev": true,
       "requires": {
-        "history": "^2.1.2",
-        "hoist-non-react-statics": "^1.2.0",
+        "create-react-class": "^15.5.1",
+        "history": "^3.0.0",
+        "hoist-non-react-statics": "^3.3.2",
         "invariant": "^2.2.1",
         "loose-envify": "^1.2.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.13.0",
         "warning": "^3.0.0"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
-          "integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs=",
-          "dev": true
-        }
       }
     },
     "react-select": {

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "react-draggable": "^3.3.2",
     "react-redux": "^5.1.2",
     "react-resizable": "^1.11.0",
-    "react-router": "^2.8.1",
+    "react-router": "^3.2.6",
     "react-select": "^1.3.0",
     "react-tabs": "^2.3.1",
     "react-virtualized": "^7.3.1",

--- a/src/renderer/actions/connections.js
+++ b/src/renderer/actions/connections.js
@@ -6,6 +6,7 @@ export const CONNECTION_REQUEST = 'CONNECTION_REQUEST';
 export const CONNECTION_SUCCESS = 'CONNECTION_SUCCESS';
 export const CONNECTION_FAILURE = 'CONNECTION_FAILURE';
 export const CONNECTION_REQUIRE_SSH_PASSPHRASE = 'CONNECTION_REQUIRE_SSH_PASSPHRASE';
+export const CONNECTION_SET_CONNECTING = 'CONNECTION_SET_CONNECTING';
 export const TEST_CONNECTION_REQUEST = 'TEST_CONNECTION_REQUEST';
 export const TEST_CONNECTION_SUCCESS = 'TEST_CONNECTION_SUCCESS';
 export const TEST_CONNECTION_FAILURE = 'TEST_CONNECTION_FAILURE';
@@ -37,6 +38,12 @@ export function getDBConnByName(database) {
   }
 
   return dbConn;
+}
+
+export function setConnecting () {
+  return (dispatch) => {
+    dispatch({ type: CONNECTION_SET_CONNECTING });
+  };
 }
 
 

--- a/src/renderer/containers/app.jsx
+++ b/src/renderer/containers/app.jsx
@@ -90,11 +90,12 @@ class AppContainer extends Component {
     // remove the loading screen quickly if disabled
     const l1 = document.getElementById('loading');
     const l2 = document.getElementById('loading-signal');
-    if (l1 && l2 && disabledOpenAnimation) {
+    const l3 = document.getElementById('loading-started');
+    if (l1 && l2 && l3 && disabledOpenAnimation) {
       l1.remove();
       l2.remove();
     }
-    if (l1 && l2 && !disabledOpenAnimation) {
+    if (l1 && l2 && l3 && !disabledOpenAnimation) {
       this.runLoadingAnimation();
     }
   }
@@ -107,6 +108,8 @@ class AppContainer extends Component {
 
   // this runs the animated loading
   runLoadingAnimation() {
+    document.getElementById('loading-started').remove();
+
     const img = new Image();
 
     img.onload = () => {

--- a/src/renderer/containers/server-management.jsx
+++ b/src/renderer/containers/server-management.jsx
@@ -53,7 +53,9 @@ class ServerManagerment extends Component {
   }
 
   onConnectClick({ id }) {
-    this.props.router.push(`/server/${id}`);
+    const { dispatch, router } = this.props;
+    dispatch(ConnActions.setConnecting());
+    router.push(`/server/${id}`);
   }
 
   onTestConnectionClick(server) {

--- a/src/renderer/entry.jsx
+++ b/src/renderer/entry.jsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
-import { Router, Route, hashHistory } from 'react-router';
+import {
+  Router,
+  Route,
+  IndexRoute,
+  hashHistory,
+} from 'react-router';
 import App from './containers/app';
 import configureStore from './store/configure';
 import ServerManagementContainer from './containers/server-management';
@@ -12,9 +17,9 @@ const store = configureStore();
 ReactDOM.render(
   <Provider store={store}>
     <Router history={hashHistory}>
-      <Route component={App}>
-        <Route path="/" component={ServerManagementContainer} />
-        <Route path="/server/:id" component={QueryBrowserContainer} />
+      <Route path="/" component={App}>
+        <IndexRoute component={ServerManagementContainer} />
+        <Route path="server/:id" component={QueryBrowserContainer} />
       </Route>
     </Router>
   </Provider>,

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -83,6 +83,7 @@
     </head>
     <body>
       <div id="content"></div>
+      <div id="loading-started"></div>
       <div id="loading-signal"></div>
       <div id="loading"></div>
       <% if (htmlWebpackPlugin.options.hot) { %>

--- a/src/renderer/reducers/connections.js
+++ b/src/renderer/reducers/connections.js
@@ -16,10 +16,16 @@ const INITIAL_STATE = {
 
 export default function(state = INITIAL_STATE, action) {
   switch (action.type) {
+    case types.CONNECTION_SET_CONNECTING: {
+      return {
+        ...INITIAL_STATE,
+        connecting: true,
+      };
+    }
     case types.CONNECTION_REQUEST: {
       const { disabledFeatures } = CLIENTS.find(dbClient => dbClient.key === action.server.client);
       return {
-        ...INITIAL_STATE,
+        ...state,
         server: action.server,
         disabledFeatures: disabledFeatures || [],
       };


### PR DESCRIPTION
Closes #537

This upgrades the react-router dependency to ^3, which brings in support for react 16 from it. I chose not to upgrade it further at this time as v4 and v5 have more extensive API changes, and as indicated in #537, upgrading react-router can happen in concert with upgrading react.