### PR TITLE
Remove sh build target for linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
       "target": [
         "deb",
         "rpm",
-        "sh",
         "freebsd",
         "pacman",
         "tar.xz",


### PR DESCRIPTION
Closes #510 

With https://github.com/electron-userland/electron-builder/issues/5285 getting closed automatically with no feedback from developer team, have to assume that `sh` builds are not a priority (or maybe even supported) for them, so better to remove them from being produced going forward, as much as some people might like to have it.