### PR TITLE
add open tab menu item to DB right click menu

### DIFF
--- a/src/renderer/components/database-list-item.jsx
+++ b/src/renderer/components/database-list-item.jsx
@@ -45,6 +45,7 @@ export default class DatabaseListItem extends Component {
     onSelectDatabase: PropTypes.func.isRequired,
     onGetSQLScript: PropTypes.func.isRequired,
     onRefreshDatabase: PropTypes.func.isRequired,
+    onOpenTab: PropTypes.func.isRequired,
     onShowDiagramModal: PropTypes.func.isRequired,
   }
 
@@ -66,6 +67,10 @@ export default class DatabaseListItem extends Component {
     this.contextMenu.append(new MenuItem({
       label: 'Refresh Database',
       click: this.props.onRefreshDatabase.bind(this, nextProps.database),
+    }));
+    this.contextMenu.append(new MenuItem({
+      label: 'Open Tab',
+      click: this.props.onOpenTab.bind(this, nextProps.database),
     }));
     this.contextMenu.append(new MenuItem({
       label: 'Show Database Diagram',

--- a/src/renderer/components/database-list.jsx
+++ b/src/renderer/components/database-list.jsx
@@ -20,6 +20,7 @@ export default class DatabaseList extends Component {
     onSelectTable: PropTypes.func.isRequired,
     onGetSQLScript: PropTypes.func.isRequired,
     onRefreshDatabase: PropTypes.func.isRequired,
+    onOpenTab: PropTypes.func.isRequired,
     onShowDiagramModal: PropTypes.func.isRequired,
   }
 
@@ -49,6 +50,7 @@ export default class DatabaseList extends Component {
       onSelectDatabase,
       onGetSQLScript,
       onRefreshDatabase,
+      onOpenTab,
       onShowDiagramModal,
       currentDB,
     } = this.props;
@@ -87,6 +89,7 @@ export default class DatabaseList extends Component {
             onSelectDatabase={onSelectDatabase}
             onGetSQLScript={onGetSQLScript}
             onRefreshDatabase={onRefreshDatabase}
+            onOpenTab={onOpenTab}
             onShowDiagramModal={onShowDiagramModal} />
         ))
       }

--- a/src/renderer/containers/query-browser.jsx
+++ b/src/renderer/containers/query-browser.jsx
@@ -128,6 +128,7 @@ class QueryBrowserContainer extends Component {
     this.onSelectTable = this.onSelectTable.bind(this);
     this.onGetSQLScript = this.onGetSQLScript.bind(this);
     this.onRefreshDatabase = this.onRefreshDatabase.bind(this);
+    this.onOpenTab = this.onOpenTab.bind(this);
     this.onShowDiagramModal = this.onShowDiagramModal.bind(this);
   }
 
@@ -272,6 +273,11 @@ class QueryBrowserContainer extends Component {
   onRefreshDatabase(database) {
     const { dispatch } = this.props;
     dispatch(DbAction.refreshDatabase(database));
+  }
+
+  onOpenTab(database) {
+    const { dispatch } = this.props;
+    dispatch(QueryActions.newQuery(database.name));
   }
 
   onShowDiagramModal(database) {
@@ -696,6 +702,7 @@ class QueryBrowserContainer extends Component {
                   onSelectTable={this.onSelectTable}
                   onGetSQLScript={this.onGetSQLScript}
                   onRefreshDatabase={this.onRefreshDatabase}
+                  onOpenTab={this.onOpenTab}
                   onShowDiagramModal={this.onShowDiagramModal} />
               </div>
             </ResizableBox>


### PR DESCRIPTION
This adds a new context menu item when right clicking on a database name to allow you to open a new tab for that database.