### PR TITLE
Add "save as" to save queries into a new file

### DIFF
--- a/src/browser/menu/darwin.js
+++ b/src/browser/menu/darwin.js
@@ -76,6 +76,11 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
           click: (item, win) => sendMessage(win, 'sqlectron:save-query'),
         },
         {
+          label: 'Save Query As',
+          accelerator: 'Shift+Cmd+S',
+          click: (item, win) => sendMessage(win, 'sqlectron:save-query-as'),
+        },
+        {
           label: 'Open Query',
           accelerator: 'Cmd+O',
           click: (item, win) => sendMessage(win, 'sqlectron:open-query'),

--- a/src/browser/menu/linux.js
+++ b/src/browser/menu/linux.js
@@ -35,6 +35,11 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
           click: (item, win) => sendMessage(win, 'sqlectron:save-query'),
         },
         {
+          label: 'Save Query As',
+          accelerator: 'Shift+Ctrl+S',
+          click: (item, win) => sendMessage(win, 'sqlectron:save-query-as'),
+        },
+        {
           label: 'Open Query',
           accelerator: 'Ctrl+O',
           click: (item, win) => sendMessage(win, 'sqlectron:open-query'),

--- a/src/browser/menu/win32.js
+++ b/src/browser/menu/win32.js
@@ -35,6 +35,11 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
           click: (item, win) => sendMessage(win, 'sqlectron:save-query'),
         },
         {
+          label: 'Save Query As',
+          accelerator: 'Ctrl+Shift+S',
+          click: (item, win) => sendMessage(win, 'sqlectron:save-query-as'),
+        },
+        {
           label: 'Open Query',
           accelerator: 'Ctrl+O',
           click: (item, win) => sendMessage(win, 'sqlectron:open-query'),

--- a/src/renderer/actions/queries.js
+++ b/src/renderer/actions/queries.js
@@ -176,7 +176,7 @@ export function saveQuery (isSaveAs) {
         { name: 'All Files', extensions: ['*'] },
       ];
 
-      let filename = getFileName(currentQuery, isSaveAs, filters);
+      let filename = await getFileName(currentQuery, isSaveAs, filters);
       if (path.extname(filename) !== '.sql') {
         filename += '.sql';
       }

--- a/src/renderer/actions/queries.js
+++ b/src/renderer/actions/queries.js
@@ -159,7 +159,14 @@ export function saveToFile (rows, type, delimiter) {
   };
 }
 
-export function saveQuery () {
+async function getFileName (currentQuery, isSaveAs, filters) {
+  if (!isSaveAs && currentQuery.filename) {
+    return currentQuery.filename;
+  }
+  return fileHandler.showSaveDialog(filters);
+}
+
+export function saveQuery (isSaveAs) {
   return async (dispatch, getState) => {
     dispatch({ type: SAVE_QUERY_REQUEST });
     try {
@@ -169,7 +176,7 @@ export function saveQuery () {
         { name: 'All Files', extensions: ['*'] },
       ];
 
-      let filename = (currentQuery.filename || await fileHandler.showSaveDialog(filters));
+      let filename = getFileName(currentQuery, isSaveAs, filters);
       if (path.extname(filename) !== '.sql') {
         filename += '.sql';
       }

--- a/src/renderer/containers/query-browser.jsx
+++ b/src/renderer/containers/query-browser.jsx
@@ -336,6 +336,7 @@ class QueryBrowserContainer extends Component {
       'sqlectron:new-tab': () => this.newTab(),
       'sqlectron:close-tab': () => this.closeTab(),
       'sqlectron:save-query': () => this.saveQuery(),
+      'sqlectron:save-query-as': () => this.saveQueryAs(),
       'sqlectron:open-query': () => this.openQuery(),
       'sqlectron:query-focus': () => this.focusQuery(),
       'sqlectron:toggle-database-search': () => this.toggleDatabaseSearch(),
@@ -357,7 +358,11 @@ class QueryBrowserContainer extends Component {
   }
 
   saveQuery() {
-    this.props.dispatch(QueryActions.saveQuery());
+    this.props.dispatch(QueryActions.saveQuery(false));
+  }
+
+  saveQueryAs() {
+    this.props.dispatch(QueryActions.saveQuery(true));
   }
 
   openQuery() {


### PR DESCRIPTION
Added the "save as" feature to save the current query into a new file.

The shortcuts are:

Windows: Ctrl+Shift+S
Linux: Ctrl+Shift+S
Mac OS: Cmd+Shift+S

Related issue: #566 