### PR TITLE
convert update-checker to react functional component

### DIFF
--- a/src/browser/update-checker.js
+++ b/src/browser/update-checker.js
@@ -2,7 +2,6 @@ import axios from 'axios';
 import createLogger from './logger';
 
 const logger = createLogger('gh-update-checker');
-const WAIT_2_SECS = 2000;
 
 export async function check(mainWindow, appConfig) {
   const currentVersion = `v${appConfig.version}`;
@@ -13,11 +12,11 @@ export async function check(mainWindow, appConfig) {
   const response = await axios.get(latestReleaseURL);
 
   logger.debug('latest version %s', response.data.tag_name);
+
   if (currentVersion === response.data.tag_name) {
     logger.debug('already using the latest version');
     return;
   }
 
-  // give some time to the render process be ready
-  setTimeout(() => mainWindow.webContents.send('sqlectron:update-available'), WAIT_2_SECS);
+  mainWindow.webContents.send('sqlectron:update-available');
 }

--- a/src/browser/update-checker.js
+++ b/src/browser/update-checker.js
@@ -18,5 +18,11 @@ export async function check(mainWindow, appConfig) {
     return;
   }
 
-  mainWindow.webContents.send('sqlectron:update-available');
+  console.log(currentVersion);
+  console.log(response.data.tag_name);
+
+  mainWindow.webContents.send('sqlectron:update-available', {
+    currentVersion,
+    latestVersion: response.data.tag_name,
+  });
 }

--- a/src/browser/window.js
+++ b/src/browser/window.js
@@ -1,5 +1,5 @@
 import { resolve } from 'path';
-import { BrowserWindow } from 'electron';
+import { BrowserWindow, ipcMain } from 'electron';
 import { attachMenuToWindow } from './menu';
 import { check as checkUpdate } from './update-checker';
 import { get as getConfig } from './config';
@@ -47,7 +47,9 @@ export function buildNewWindow(app) {
     mainWindow.openDevTools();
   }
 
-  checkUpdate(mainWindow, appConfig).catch((err) =>
-    logger.error('Unable to check for updates', err)
-  );
+  ipcMain.on('sqlectron:check-upgrade', () => {
+    checkUpdate(mainWindow, appConfig).catch((err) =>
+      logger.error('Unable to check for updates', err)
+    );
+  });
 }

--- a/src/renderer/components/update-checker.jsx
+++ b/src/renderer/components/update-checker.jsx
@@ -7,8 +7,12 @@ const LATEST_RELEASE_URL = `https://github.com/${repo}/releases/latest`;
 
 const UpdateChecker = () => {
   const [isVisible, setIsVisible] = useState(false);
+  //const [currentVersion, setCurrentVersion] = useState('');
+  const [latestVersion, setLatestVersion] = useState('');
 
-  const updateAvailable = () => {
+  const updateAvailable = (_, { /*currentVersion,*/ latestVersion }) => {
+    //setCurrentVersion(currentVersion);
+    setLatestVersion(latestVersion);
     setIsVisible(true);
   };
 
@@ -30,7 +34,8 @@ const UpdateChecker = () => {
     <>
       {isVisible && (
         <a className="ui green label" onClick={onClick}>
-          <i className="cloud download icon">Update available</i>
+          <i className="cloud download icon" />
+          Update available: {latestVersion}
         </a>
       )}
     </>

--- a/src/renderer/components/update-checker.jsx
+++ b/src/renderer/components/update-checker.jsx
@@ -1,50 +1,42 @@
 import { ipcRenderer, shell } from 'electron';
-import React, { Component } from 'react';
+import React, { useEffect, useState } from 'react';
 
 const EVENT_KEY = 'sqlectron:update-available';
 const repo = global.SQLECTRON_CONFIG.repository.url.replace('https://github.com/', '');
 const LATEST_RELEASE_URL = `https://github.com/${repo}/releases/latest`;
 
-export default class UpdateChecker extends Component {
-  constructor(props, context) {
-    super(props, context);
+const UpdateChecker = () => {
+  const [isVisible, setIsVisible] = useState(false);
 
-    this.onUpdateAvailable = this.onUpdateAvailable.bind(this);
-  }
+  const updateAvailable = () => {
+    setIsVisible(true);
+  };
 
-  componentDidMount() {
-    ipcRenderer.on(EVENT_KEY, this.onUpdateAvailable);
-  }
-
-  componentWillUnmount() {
-    ipcRenderer.removeListener(EVENT_KEY, this.onUpdateAvailable);
-  }
-
-  onUpdateAvailable() {
-    this.setState({ isVisible: true });
-  }
-
-  onUpdateClick(event) {
+  const onClick = (event) => {
     event.preventDefault();
     shell.openExternal(LATEST_RELEASE_URL);
-  }
+  };
 
-  render() {
-    const isVisible = this.state && this.state.isVisible;
-    if (!isVisible) {
-      return null;
-    }
+  useEffect(() => {
+    ipcRenderer.on(EVENT_KEY, updateAvailable);
+    ipcRenderer.send('sqlectron:check-upgrade');
 
-    // TODO: show the latest avaible version
-    // const currentVersion = `v${PACKAGE_JSON.version}`;
-    // const availableVersion = '...';
+    return () => {
+      ipcRenderer.removeListener(EVENT_KEY, updateAvailable);
+    };
+  }, []);
 
-    return (
-      <a className="ui green label" onClick={this.onUpdateClick}>
-        <i className="cloud download icon" />
-        Update available
-        {/* <div className="detail">{APP_VERSION}</div> */}
-      </a>
-    );
-  }
-}
+  return (
+    <>
+      {isVisible && (
+        <a className="ui green label" onClick={onClick}>
+          <i className="cloud download icon">Update available</i>
+        </a>
+      )}
+    </>
+  );
+};
+
+UpdateChecker.displayName = 'UpdateChecker';
+
+export default UpdateChecker;


### PR DESCRIPTION
Converts the update-checker to a functional component using hooks. Additionally, I cleaned up the integration of the box appearing to make it a bit more consistent on the dev build as that would often times take longer than 2 seconds to boot up. Now, we wait first for the update-checker component to have mounted, and then the main process checks for version and notifies back. Could also modify to kick off interval to check version string in the future.