### PR TITLE
upgrade react-redux to ^7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11254,18 +11254,27 @@
       "dev": true
     },
     "react-redux": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.2.tgz",
-      "integrity": "sha512-Ns1G0XXc8hDyH/OcBHOxNgQx9ayH3SPxBnFCOidGKSle8pKihysQw2rG/PmciUQRoclhVBO8HMhiRmGXnDja9Q==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.2.tgz",
+      "integrity": "sha512-8+CQ1EvIVFkYL/vu6Olo7JFLWop1qRUeb46sGtIMDCSpgwPQq8fPLpirIB0iTqFe9XYEFPHssdX8/UwN6pAkEA==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.1.2",
-        "hoist-non-react-statics": "^3.3.0",
-        "invariant": "^2.2.4",
-        "loose-envify": "^1.1.0",
-        "prop-types": "^15.6.1",
-        "react-is": "^16.6.0",
-        "react-lifecycles-compat": "^3.0.0"
+        "@babel/runtime": "^7.12.1",
+        "hoist-non-react-statics": "^3.3.2",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.13.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.8",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.8.tgz",
+          "integrity": "sha512-CwQljpw6qSayc0fRG1soxHAKs1CnQMOChm4mlQP6My0kf9upVGizj/KhlTTgyUnETmHpcUXjaluNAkteRFuafg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
       }
     },
     "react-resizable": {

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "react-ace": "^7.0.5",
     "react-dom": "^16.14.0",
     "react-draggable": "^3.3.2",
-    "react-redux": "^5.1.2",
+    "react-redux": "^7.2.2",
     "react-resizable": "^1.11.0",
     "react-router": "^3.2.6",
     "react-select": "^1.3.0",


### PR DESCRIPTION
This upgrades react-redux to its latest version, which we can do as it places a minimum requirement of React 16.8. This will allow us to now rewrite components that utilize redux to use its new hooks.