### PR TITLE
remove deprecated context constructor arg

### DIFF
--- a/src/renderer/components/database-diagram-modal.jsx
+++ b/src/renderer/components/database-diagram-modal.jsx
@@ -31,8 +31,8 @@ export default class DatabaseDiagramModal extends Component {
     onClose: PropTypes.func.isRequired,
   };
 
-  constructor(props, context) {
-    super(props, context);
+  constructor(props) {
+    super(props);
     this.state = {};
 
     this.onSelectAllTables = this.onSelectAllTables.bind(this);

--- a/src/renderer/components/database-filter.jsx
+++ b/src/renderer/components/database-filter.jsx
@@ -9,8 +9,8 @@ export default class DatabaseFilter extends Component {
     onFilterChange: PropTypes.func.isRequired,
   };
 
-  constructor(props, context) {
-    super(props, context);
+  constructor(props) {
+    super(props);
 
     this.onFilterChange = this.onFilterChange.bind(this);
   }

--- a/src/renderer/components/database-item.jsx
+++ b/src/renderer/components/database-item.jsx
@@ -24,8 +24,8 @@ export default class DatabaseItem extends Component {
     onGetSQLScript: PropTypes.func,
   };
 
-  constructor(props, context) {
-    super(props, context);
+  constructor(props) {
+    super(props);
     this.state = {};
     this.contextMenu = null;
 

--- a/src/renderer/components/database-list-item-metadata.jsx
+++ b/src/renderer/components/database-list-item-metadata.jsx
@@ -25,8 +25,8 @@ export default class DbMetadataList extends Component {
     onGetSQLScript: PropTypes.func,
   };
 
-  constructor(props, context) {
-    super(props, context);
+  constructor(props) {
+    super(props);
     this.state = { tableCollapsed: {} };
 
     this.toggleCollapse = this.toggleCollapse.bind(this);

--- a/src/renderer/components/database-list-item.jsx
+++ b/src/renderer/components/database-list-item.jsx
@@ -49,8 +49,8 @@ export default class DatabaseListItem extends Component {
     onShowDiagramModal: PropTypes.func.isRequired,
   };
 
-  constructor(props, context) {
-    super(props, context);
+  constructor(props) {
+    super(props);
     this.state = {};
     this.contextMenu = null;
 

--- a/src/renderer/components/database-list.jsx
+++ b/src/renderer/components/database-list.jsx
@@ -24,8 +24,8 @@ export default class DatabaseList extends Component {
     onShowDiagramModal: PropTypes.func.isRequired,
   };
 
-  constructor(props, context) {
-    super(props, context);
+  constructor(props) {
+    super(props);
     this.state = {};
   }
 

--- a/src/renderer/components/message.jsx
+++ b/src/renderer/components/message.jsx
@@ -10,8 +10,8 @@ export default class Message extends Component {
     preformatted: PropTypes.bool,
   };
 
-  constructor(props, context) {
-    super(props, context);
+  constructor(props) {
+    super(props);
 
     this.onClose = this.onClose.bind(this);
   }

--- a/src/renderer/components/preview-modal.jsx
+++ b/src/renderer/components/preview-modal.jsx
@@ -9,8 +9,8 @@ export default class PreviewModal extends Component {
     onCloseClick: PropTypes.func.isRequired,
   };
 
-  constructor(props, context) {
-    super(props, context);
+  constructor(props) {
+    super(props);
     this.state = {};
   }
 

--- a/src/renderer/components/prompt-modal.jsx
+++ b/src/renderer/components/prompt-modal.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, createRef } from 'react';
 import PropTypes from 'prop-types';
 
 export default class PromptModal extends Component {
@@ -10,15 +10,17 @@ export default class PromptModal extends Component {
     type: PropTypes.string.isRequired,
   };
 
-  constructor(props, context) {
-    super(props, context);
+  constructor(props) {
+    super(props);
 
     this.handleChange = this.handleChange.bind(this);
     this.handleKeyPress = this.handleKeyPress.bind(this);
+
+    this.ref = createRef();
   }
 
   componentDidMount() {
-    $(this.refs.promptModal)
+    $(this.ref.current)
       .modal({
         closable: false,
         detachable: false,
@@ -35,7 +37,7 @@ export default class PromptModal extends Component {
   }
 
   componentWillUnmount() {
-    $(this.refs.promptModal).modal('hide');
+    $(this.ref.current).modal('hide');
   }
 
   handleKeyPress(event) {
@@ -52,7 +54,7 @@ export default class PromptModal extends Component {
     const { title, message, type } = this.props;
 
     return (
-      <div className="ui modal" ref="promptModal">
+      <div className="ui modal" ref={this.ref}>
         <div className="header">{title}</div>
         <div className="content">
           {message}

--- a/src/renderer/components/query-result-table-cell.jsx
+++ b/src/renderer/components/query-result-table-cell.jsx
@@ -15,8 +15,8 @@ export default class TableCell extends Component {
     onOpenPreviewClick: PropTypes.func.isRequired,
   };
 
-  constructor(props, context) {
-    super(props, context);
+  constructor(props) {
+    super(props);
     this.contextMenu = null;
 
     this.onContextMenu = this.onContextMenu.bind(this);

--- a/src/renderer/components/query-result-table.jsx
+++ b/src/renderer/components/query-result-table.jsx
@@ -41,8 +41,8 @@ export default class QueryResultTable extends Component {
     rowCount: PropTypes.oneOfType([PropTypes.array, PropTypes.number]),
   };
 
-  constructor(props, context) {
-    super(props, context);
+  constructor(props) {
+    super(props);
     this.state = {
       columnWidths: {},
       autoColumnWidths: [],

--- a/src/renderer/components/query.jsx
+++ b/src/renderer/components/query.jsx
@@ -61,8 +61,8 @@ export default class Query extends Component {
     editorName: PropTypes.string.isRequired,
   };
 
-  constructor(props, context) {
-    super(props, context);
+  constructor(props) {
+    super(props);
     this.state = {
       wrapEnabled: false,
     };

--- a/src/renderer/components/server-filter.jsx
+++ b/src/renderer/components/server-filter.jsx
@@ -9,8 +9,8 @@ export default class ServerFilter extends Component {
     onSettingsClick: PropTypes.func.isRequired,
   };
 
-  constructor(props, context) {
-    super(props, context);
+  constructor(props) {
+    super(props);
 
     this.onFilterChange = this.onFilterChange.bind(this);
   }

--- a/src/renderer/components/server-modal-form.jsx
+++ b/src/renderer/components/server-modal-form.jsx
@@ -33,8 +33,8 @@ export default class ServerModalForm extends Component {
     testConnection: PropTypes.object,
   };
 
-  constructor(props, context) {
-    super(props, context);
+  constructor(props) {
+    super(props);
     const server = props.server || {};
     this.state = {
       ...server,

--- a/src/renderer/components/settings-modal-form.jsx
+++ b/src/renderer/components/settings-modal-form.jsx
@@ -17,8 +17,8 @@ export default class SettingsModalForm extends Component {
     error: PropTypes.object,
   };
 
-  constructor(props, context) {
-    super(props, context);
+  constructor(props) {
+    super(props);
     this.state = {
       ...props.config.data,
     };

--- a/src/renderer/components/table-submenu.jsx
+++ b/src/renderer/components/table-submenu.jsx
@@ -17,8 +17,8 @@ export default class TableSubmenu extends Component {
     onDoubleClickItem: PropTypes.func,
   };
 
-  constructor(props, context) {
-    super(props, context);
+  constructor(props) {
+    super(props);
     this.state = {};
 
     this.toggleCollapse = this.toggleCollapse.bind(this);

--- a/src/renderer/containers/app.jsx
+++ b/src/renderer/containers/app.jsx
@@ -24,8 +24,8 @@ class AppContainer extends Component {
     children: PropTypes.node,
   };
 
-  constructor(props, context) {
-    super(props, context);
+  constructor(props) {
+    super(props);
     this.state = {};
 
     this.menuHandler = new MenuHandler();

--- a/src/renderer/containers/query-browser.jsx
+++ b/src/renderer/containers/query-browser.jsx
@@ -93,8 +93,8 @@ class QueryBrowserContainer extends Component {
     children: PropTypes.node,
   };
 
-  constructor(props, context) {
-    super(props, context);
+  constructor(props) {
+    super(props);
     this.state = {
       tabNavPosition: 0,
       sideBarWidth: SIDEBAR_WIDTH,


### PR DESCRIPTION
The `context` argument to the constructor is part of the [legacy context](https://reactjs.org/docs/legacy-context.html) system that React put in place in its early days. Nowadays, there's other, better ways to do context if you need it, however, the context system is not used at all, so we can just safely remove the arg and do no migration stuff.