### PR TITLE
prevent outside sqlectron navigation

### DIFF
--- a/src/browser/window.js
+++ b/src/browser/window.js
@@ -42,7 +42,17 @@ export function buildNewWindow(app) {
     entryBasePath = 'http://localhost:8080';
   }
 
-  mainWindow.loadURL(entryBasePath + '/static/index.html');
+  const appUrl = entryBasePath + '/static/index.html';
+
+  mainWindow.loadURL(appUrl);
+
+  // block navigation that would lead outside the application
+  mainWindow.webContents.on('will-navigate', (e, url) => {
+    if (url === appUrl) {
+      return;
+    }
+    e.preventDefault();
+  });
 
   // Emitted when the window is closed.
   mainWindow.on('closed', () => delete WINDOWS[windowsNumber]);


### PR DESCRIPTION
Closes #466

Adds a handler for `will-navigate` to prevent it from going to a URL that is not the URL of the electron window itself. Not sure how they triggered the issue within that issue, but tested that this fixes it by trying to do `window.location = 'https://example.com';` within the developer console. Without the patch, it would go to the site, with patch, it will not.