### PR TITLE
Fix linux build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,15 +12,16 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      node-version: 14
+      node-version: 10
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # TODO: upgrade to latest Ubuntu
+        os: [ubuntu-18.04, macos-latest, windows-latest]
 
     steps:
     - name: Install Linux Dependencies
-      if: ${{ matrix.os == 'ubuntu-latest' }}
+      if: runner.os == 'Linux'
       run: sudo apt-get install libgnome-keyring-dev icnsutils graphicsmagick rpm bsdtar
 
     - uses: actions/checkout@v2
@@ -37,11 +38,11 @@ jobs:
     - run: npm run format:check
 
     - name: Build app for e2e test
-      if: ${{ matrix.os == 'ubuntu-latest' }}
+      if: runner.os == 'Linux'
       run: npm run compile
 
     - name: Run e2e test
-      if: ${{ matrix.os == 'ubuntu-latest' }}
+      if: runner.os == 'Linux'
       run: xvfb-run --auto-servernum npm run test:e2e
 
     - run: npm run dist -- --publish never

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,11 +14,12 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # TODO: upgrade to latest Ubuntu
+        os: [ubuntu-18.04, macos-latest, windows-latest]
 
     steps:
     - name: Install Linux Dependencies
-      if: ${{ matrix.os == 'ubuntu-latest' }}
+      if: runner.os == 'Linux'
       run: |
         sudo apt-get update
         sudo apt-get install libgnome-keyring-dev icnsutils graphicsmagick rpm bsdtar gcc-multilib g++-multilib
@@ -35,11 +36,11 @@ jobs:
     - run: npm test
 
     - run: npm run dist
+      if: runner.os == 'macOS'
       env:
         GH_TOKEN: ${{ secrets.GH_TOKEN }}
-      if: ${{ matrix.os == 'macos-latest' }}
 
     - run: npm run dist:all-arch
+      if: runner.os != 'macOS'
       env:
         GH_TOKEN: ${{ secrets.GH_TOKEN }}
-      if: ${{ matrix.os != 'macos-latest' }}


### PR DESCRIPTION
Fix the linux build: https://github.com/sqlectron/sqlectron-gui/runs/2018631610

```
Run sudo apt-get install libgnome-keyring-dev icnsutils graphicsmagick rpm bsdtar
Reading package lists...
Building dependency tree...
Reading state information...
Package bsdtar is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  libarchive-tools
````