### PR TITLE
Fix lint issues for src/browser

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -88,7 +88,7 @@ module.exports = {
       },
     },
     {
-      files: ['src/**/*.ts', 'src/**/*.tsx'],
+      files: ['src/renderer/**/*.ts', 'src/renderer/**/*.tsx'],
       env: { browser: true, es6: true, node: true },
       extends: [
         'eslint:recommended',
@@ -116,6 +116,29 @@ module.exports = {
       },
     },
     {
+      files: ['src/browser/**/*.ts', 'src/common/**/*.ts'],
+      env: { browser: true, es6: true, node: true },
+      extends: [
+        'eslint:recommended',
+        'plugin:@typescript-eslint/recommended',
+        'plugin:prettier/recommended',
+      ],
+      globals: { NodeJS: true, Atomics: 'readonly', SharedArrayBuffer: 'readonly' },
+      parser: '@typescript-eslint/parser',
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+        ecmaVersion: 2020,
+        sourceType: 'module',
+        project: './tsconfig.json',
+      },
+      plugins: ['prettier', '@typescript-eslint'],
+      rules: {
+        'no-unused-vars': 'off',
+        '@typescript-eslint/ban-ts-comment': 'off',
+        '@typescript-eslint/no-explicit-any': 'off',
+      },
+    },
+    {
       files: ['test/**/*.ts', 'test/**/*.tsx'],
       env: { browser: true, es6: true, node: true },
       extends: [
@@ -137,7 +160,6 @@ module.exports = {
         'no-unused-vars': 'off',
         '@typescript-eslint/ban-ts-comment': 'off',
         '@typescript-eslint/no-explicit-any': 'off',
-        '@typescript-eslint/explicit-module-boundary-types': 'off', // temporary disable for tests
         '@typescript-eslint/no-non-null-assertion': 'off',
       },
       settings: {

--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -46,7 +46,7 @@ export function getConfig(cleanCache = false): Config {
     log: {
       console: isDev,
       file: false,
-      level: appConfig.level || (process.env.DEBUG ? 'debug' : 'error'),
+      level: appConfig.log.level || (process.env.DEBUG ? 'debug' : 'error'),
       path: configPath.replace('.json', '.log'),
     },
   };

--- a/src/browser/core/config.ts
+++ b/src/browser/core/config.ts
@@ -1,8 +1,9 @@
 import { v4 as uuidv4 } from 'uuid';
 import * as utils from './utils';
 import * as crypto from './crypto';
+import { Config } from '../../common/types/config';
 
-const EMPTY_CONFIG = { servers: [] };
+const EMPTY_CONFIG = <Config>{};
 
 function sanitizeServer(server, cryptoSecret) {
   const srv = { ...server };
@@ -48,7 +49,7 @@ function sanitizeServers(data, cryptoSecret) {
 /**
  * Prepare the configuration file sanitizing and validating all fields availbale
  */
-export async function prepare(cryptoSecret) {
+export async function prepare(cryptoSecret: string): Promise<void> {
   const filename = utils.getConfigPath();
   const fileExistsResult = await utils.fileExists(filename);
   if (!fileExistsResult) {
@@ -68,7 +69,7 @@ export async function prepare(cryptoSecret) {
   // }
 }
 
-export function prepareSync(cryptoSecret) {
+export function prepareSync(cryptoSecret: string): void {
   const filename = utils.getConfigPath();
   const fileExistsResult = utils.fileExistsSync(filename);
   if (!fileExistsResult) {
@@ -88,27 +89,27 @@ export function prepareSync(cryptoSecret) {
   // }
 }
 
-export function path() {
+export function path(): string {
   const filename = utils.getConfigPath();
   return utils.resolveHomePathToAbsolute(filename);
 }
 
-export function get() {
+export function get(): Promise<Config> {
   const filename = utils.getConfigPath();
   return utils.readJSONFile(filename);
 }
 
-export function getSync() {
+export function getSync(): Config {
   const filename = utils.getConfigPath();
   return utils.readJSONFileSync(filename);
 }
 
-export function save(data) {
+export function save(data: Config): Promise<void> {
   const filename = utils.getConfigPath();
   return utils.writeJSONFile(filename, data);
 }
 
-export async function saveSettings(data) {
+export async function saveSettings(data: Config): Promise<void> {
   const fullData = await get();
   const filename = utils.getConfigPath();
   const newData = { ...fullData, ...data };

--- a/src/browser/core/crypto.ts
+++ b/src/browser/core/crypto.ts
@@ -1,9 +1,10 @@
 // Reference: http://lollyrock.com/articles/nodejs-encryption
 import crypto from 'crypto';
+import { EncryptedPassword } from '../../common/types/server';
 
 const algorithm = 'aes-256-cbc';
 
-export function encrypt(plainText, secret) {
+export function encrypt(plainText: string, secret: string): EncryptedPassword {
   if (!plainText) {
     throw new Error('Missing plain text');
   } else if (!secret) {
@@ -19,7 +20,7 @@ export function encrypt(plainText, secret) {
   };
 }
 
-export function decrypt(encrypted, secret) {
+export function decrypt(encrypted: EncryptedPassword, secret: string): string {
   if (!encrypted || !encrypted.ivText || !encrypted.encryptedText) {
     throw new Error('Invalid encrypted valued');
   } else if (!secret) {
@@ -52,7 +53,7 @@ export function decrypt(encrypted, secret) {
  * @param {string} text
  * @param {string} secret
  */
-export function unsafeDecrypt(text, secret) {
+export function unsafeDecrypt(text: string, secret: string): string {
   if (!secret) {
     throw new Error('Missing crypto secret');
   }

--- a/src/browser/core/limit.ts
+++ b/src/browser/core/limit.ts
@@ -4,13 +4,13 @@ import {
 } from 'sqlectron-db-core/database';
 import * as config from './config';
 
-export async function setSelectLimit() {
+export async function setSelectLimit(): Promise<void> {
   const { limitQueryDefaultSelectTop } = await config.get();
   if (limitQueryDefaultSelectTop !== null && limitQueryDefaultSelectTop !== undefined) {
     internalSet(limitQueryDefaultSelectTop);
   }
 }
 
-export function clearSelectLimit() {
+export function clearSelectLimit(): void {
   internalClear();
 }

--- a/src/browser/core/servers.ts
+++ b/src/browser/core/servers.ts
@@ -2,13 +2,14 @@ import { v4 as uuidv4 } from 'uuid';
 import { validate, validateUniqueId } from './validators/server';
 import * as config from './config';
 import * as crypto from './crypto';
+import { Server, EncryptedPassword } from '../../common/types/server';
 
-export async function getAll() {
+export async function getAll(): Promise<Array<Server>> {
   const { servers } = await config.get();
   return servers;
 }
 
-export async function add(server, cryptoSecret) {
+export async function add(server: Server, cryptoSecret: string): Promise<Server> {
   let srv = { ...server };
   await validate(srv);
 
@@ -27,7 +28,7 @@ export async function add(server, cryptoSecret) {
   return srv;
 }
 
-export async function update(server, cryptoSecret) {
+export async function update(server: Server, cryptoSecret: string): Promise<Server> {
   let srv = { ...server };
   await validate(srv);
 
@@ -43,13 +44,13 @@ export async function update(server, cryptoSecret) {
   return server;
 }
 
-export function addOrUpdate(server, cryptoSecret) {
+export function addOrUpdate(server: Server, cryptoSecret: string): Promise<Server> {
   const hasId = !!(server.id && String(server.id).length);
   // TODO: Add validation to check if the current id is a valid uuid
   return hasId ? update(server, cryptoSecret) : add(server, cryptoSecret);
 }
 
-export async function removeById(id) {
+export async function removeById(id: string): Promise<void> {
   const data = await config.get();
 
   const index = data.servers.findIndex((srv) => srv.id === id);
@@ -59,7 +60,7 @@ export async function removeById(id) {
 }
 
 // ensure all secret fields are encrypted
-function encryptSecrects(server, cryptoSecret, oldServer?) {
+function encryptSecrects(server: Server, cryptoSecret: string, oldServer?: Server): Server {
   const updatedServer = { ...server };
 
   if (server.password) {
@@ -88,11 +89,11 @@ function encryptSecrects(server, cryptoSecret, oldServer?) {
       oldServer.encrypted
     ) {
       if (server.password === oldServer.password) {
-        updatedServer.password = crypto.unsafeDecrypt(oldServer.password, cryptoSecret);
+        updatedServer.password = crypto.unsafeDecrypt(oldServer.password as string, cryptoSecret);
       }
     }
 
-    if (typeof updatedServer.ssh.password === 'string') {
+    if (updatedServer.ssh && typeof updatedServer.ssh.password === 'string') {
       updatedServer.ssh.password = crypto.encrypt(updatedServer.ssh.password, cryptoSecret);
     }
   }
@@ -102,22 +103,30 @@ function encryptSecrects(server, cryptoSecret, oldServer?) {
 }
 
 // decrypt secret fields
-export function decryptSecrects(server, cryptoSecret) {
+export function decryptSecrects(server: Server, cryptoSecret: string): Server {
   const updatedServer = { ...server };
   if (!server.encrypted) {
     return server;
   }
 
-  if (server.password && typeof server.password === 'string') {
-    updatedServer.password = crypto.unsafeDecrypt(server.password, cryptoSecret);
-  } else if (server.password) {
-    updatedServer.password = crypto.decrypt(server.password, cryptoSecret);
+  if (server.password) {
+    if (typeof server.password === 'string') {
+      updatedServer.password = crypto.unsafeDecrypt(server.password, cryptoSecret);
+    }
+    {
+      updatedServer.password = crypto.decrypt(server.password as EncryptedPassword, cryptoSecret);
+    }
   }
 
-  if (server.ssh && server.ssh.password && typeof server.ssh.password === 'string') {
-    updatedServer.ssh.password = crypto.unsafeDecrypt(server.ssh.password, cryptoSecret);
-  } else if (server.ssh && server.ssh.password) {
-    updatedServer.ssh.password = crypto.decrypt(server.ssh.password, cryptoSecret);
+  if (server.ssh && server.ssh.password && updatedServer.ssh) {
+    if (typeof server.ssh.password === 'string') {
+      updatedServer.ssh.password = crypto.unsafeDecrypt(server.ssh.password, cryptoSecret);
+    } else {
+      updatedServer.ssh.password = crypto.decrypt(
+        server.ssh.password as EncryptedPassword,
+        cryptoSecret,
+      );
+    }
   }
 
   updatedServer.encrypted = false;

--- a/src/browser/core/servers.ts
+++ b/src/browser/core/servers.ts
@@ -112,8 +112,7 @@ export function decryptSecrects(server: Server, cryptoSecret: string): Server {
   if (server.password) {
     if (typeof server.password === 'string') {
       updatedServer.password = crypto.unsafeDecrypt(server.password, cryptoSecret);
-    }
-    {
+    } else {
       updatedServer.password = crypto.decrypt(server.password as EncryptedPassword, cryptoSecret);
     }
   }

--- a/src/browser/core/utils.ts
+++ b/src/browser/core/utils.ts
@@ -5,6 +5,7 @@ import mkdirp from 'mkdirp';
 import envPaths from 'env-paths';
 
 import { readFile, resolveHomePathToAbsolute } from 'sqlectron-db-core/utils';
+import { Config } from '../../common/types/config';
 
 export {
   createCancelablePromise,
@@ -16,7 +17,7 @@ export {
 
 let configPath = '';
 
-export function getConfigPath() {
+export function getConfigPath(): string {
   if (configPath) {
     return configPath;
   }
@@ -36,7 +37,7 @@ export function getConfigPath() {
   return configPath;
 }
 
-export function fileExists(filename) {
+export function fileExists(filename: string): Promise<boolean> {
   return new Promise((resolve) => {
     fs.stat(filename, (err, stats) => {
       if (err) return resolve(false);
@@ -45,7 +46,7 @@ export function fileExists(filename) {
   });
 }
 
-export function fileExistsSync(filename) {
+export function fileExistsSync(filename: string): boolean {
   try {
     return fs.statSync(filename).isFile();
   } catch (e) {
@@ -53,7 +54,7 @@ export function fileExistsSync(filename) {
   }
 }
 
-export function writeFile(filename, data): Promise<void> {
+export function writeFile(filename: string, data: string): Promise<void> {
   return new Promise((resolve, reject) => {
     fs.writeFile(filename, data, (err) => {
       if (err) return reject(err);
@@ -62,28 +63,28 @@ export function writeFile(filename, data): Promise<void> {
   });
 }
 
-export function writeJSONFile(filename, data) {
+export function writeJSONFile(filename: string, data: Config): Promise<void> {
   return writeFile(filename, JSON.stringify(data, null, 2));
 }
 
-export function writeJSONFileSync(filename, data) {
+export function writeJSONFileSync(filename: string, data: Config): void {
   return fs.writeFileSync(filename, JSON.stringify(data, null, 2));
 }
 
-export function readJSONFile(filename) {
+export function readJSONFile(filename: string): Promise<Config> {
   return readFile(filename).then((data) => JSON.parse(data));
 }
 
-export function readJSONFileSync(filename) {
+export function readJSONFileSync(filename: string): Config {
   const filePath = resolveHomePathToAbsolute(filename);
   const data = fs.readFileSync(path.resolve(filePath), { encoding: 'utf-8' });
   return JSON.parse(data);
 }
 
-export function createParentDirectory(filename) {
+export function createParentDirectory(filename: string): void {
   return mkdirp(path.dirname(filename));
 }
 
-export function createParentDirectorySync(filename) {
+export function createParentDirectorySync(filename: string): void {
   mkdirp.sync(path.dirname(filename));
 }

--- a/src/browser/core/validators/server.ts
+++ b/src/browser/core/validators/server.ts
@@ -1,5 +1,6 @@
 import Valida from 'valida2';
 import { CLIENTS } from 'sqlectron-db-core';
+import { Server } from '../../../common/types/server';
 
 function serverAddressValidator(ctx) {
   const { host, port, socketPath } = ctx.obj;
@@ -130,7 +131,7 @@ const SERVER_SCHEMA = {
 /**
  * validations applied on creating/updating a server
  */
-export async function validate(server) {
+export async function validate(server: Server): Promise<void> {
   const serverSchema = { ...SERVER_SCHEMA };
 
   const clientConfig = CLIENTS.find((dbClient) => dbClient.key === server.client);
@@ -149,7 +150,7 @@ export async function validate(server) {
   }
 }
 
-export function validateUniqueId(servers, serverId) {
+export function validateUniqueId(servers: Array<Server>, serverId?: string | null): boolean {
   if (!serverId) {
     throw new Error('serverId should be set');
   }

--- a/src/browser/menu/darwin.ts
+++ b/src/browser/menu/darwin.ts
@@ -1,14 +1,13 @@
 import { shell } from 'electron';
 import { BrowserWindow, App, MenuItem, MenuItemConstructorOptions } from 'electron';
 import { Config } from '../../common/types/config';
+import { BuildWindow } from '../../common/types/menu';
 
 function sendMessage(win: BrowserWindow, message: string) {
   if (win) {
     win.webContents.send(message);
   }
 }
-
-type BuildWindow = (app: App) => void; // eslint-disable-line no-unused-vars
 
 export function buildTemplate(
   app: App,

--- a/src/browser/menu/darwin.ts
+++ b/src/browser/menu/darwin.ts
@@ -1,18 +1,31 @@
 import { shell } from 'electron';
+import { BrowserWindow, App, MenuItem, MenuItemConstructorOptions } from 'electron';
+import { Config } from '../../common/types/config';
 
-function sendMessage(win, message) {
+function sendMessage(win: BrowserWindow, message: string) {
   if (win) {
     win.webContents.send(message);
   }
 }
 
-export function buildTemplate(app, buildNewWindow, appConfig) {
+type BuildWindow = (app: App) => void; // eslint-disable-line no-unused-vars
+
+export function buildTemplate(
+  app: App,
+  buildNewWindow: BuildWindow,
+  appConfig: Config,
+): Array<MenuItemConstructorOptions | MenuItem> {
   return [
     {
       label: appConfig.name,
       submenu: [
         {
           label: `About ${appConfig.name}`,
+          // TODO: selector property isn't a field in the menu constructor.
+          // It is specific for macOS https://github.com/electron/electron/issues/2268
+          // Find out if it still works and check if there is another way to achieve this
+          // without having to ignore this typescript error.
+          // @ts-ignore
           selector: 'orderFrontStandardAboutPanel:',
         },
         {
@@ -28,15 +41,17 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
         {
           label: `Hide ${appConfig.name}`,
           accelerator: 'Cmd+H',
-          selector: 'hide:',
+          role: 'hide',
         },
         {
           label: 'Hide Others',
           accelerator: 'Cmd+Shift+H',
+          // @ts-ignore
           selector: 'hideOtherApplications:',
         },
         {
           label: 'Show All',
+          // @ts-ignore
           selector: 'unhideAllApplications:',
         },
         {
@@ -60,12 +75,12 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
         {
           label: 'New Tab',
           accelerator: 'Cmd+T',
-          click: (item, win) => sendMessage(win, 'sqlectron:new-tab'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:new-tab'),
         },
         {
           label: 'Close Tab',
           accelerator: 'Cmd+W',
-          click: (item, win) => sendMessage(win, 'sqlectron:close-tab'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:close-tab'),
         },
         {
           type: 'separator',
@@ -73,17 +88,17 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
         {
           label: 'Save Query',
           accelerator: 'Cmd+S',
-          click: (item, win) => sendMessage(win, 'sqlectron:save-query'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:save-query'),
         },
         {
           label: 'Save Query As',
           accelerator: 'Shift+Cmd+S',
-          click: (item, win) => sendMessage(win, 'sqlectron:save-query-as'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:save-query-as'),
         },
         {
           label: 'Open Query',
           accelerator: 'Cmd+O',
-          click: (item, win) => sendMessage(win, 'sqlectron:open-query'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:open-query'),
         },
       ],
     },
@@ -93,17 +108,17 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
         {
           label: 'Execute',
           accelerator: 'Cmd+Enter',
-          click: (item, win) => sendMessage(win, 'sqlectron:query-execute'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:query-execute'),
         },
         {
           label: 'Execute',
           accelerator: 'Cmd+R',
-          click: (item, win) => sendMessage(win, 'sqlectron:query-execute'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:query-execute'),
         },
         {
           label: 'Focus Query Editor',
           accelerator: 'Shift+Cmd+0',
-          click: (item, win) => sendMessage(win, 'sqlectron:query-focus'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:query-focus'),
         },
       ],
     },
@@ -113,12 +128,12 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
         {
           label: 'Undo',
           accelerator: 'Cmd+Z',
-          selector: 'undo:',
+          role: 'undo',
         },
         {
           label: 'Redo',
           accelerator: 'Shift+Cmd+Z',
-          selector: 'redo:',
+          role: 'redo',
         },
         {
           type: 'separator',
@@ -126,22 +141,22 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
         {
           label: 'Cut',
           accelerator: 'Cmd+X',
-          selector: 'cut:',
+          role: 'cut',
         },
         {
           label: 'Copy',
           accelerator: 'Cmd+C',
-          selector: 'copy:',
+          role: 'copy',
         },
         {
           label: 'Paste',
           accelerator: 'Cmd+V',
-          selector: 'paste:',
+          role: 'paste',
         },
         {
           label: 'Select All',
           accelerator: 'Cmd+A',
-          selector: 'selectAll:',
+          role: 'selectAll',
         },
       ],
     },
@@ -151,12 +166,12 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
         {
           label: 'Reload',
           accelerator: 'Cmd+Shift+R',
-          click: (item, win) => win.webContents.reloadIgnoringCache(),
+          click: (item, win) => (win as BrowserWindow).webContents.reloadIgnoringCache(),
         },
         {
           label: 'Toggle DevTools',
           accelerator: 'Alt+Cmd+I',
-          click: (item, win) => win.toggleDevTools(),
+          click: (item, win) => (win as BrowserWindow).webContents.toggleDevTools(),
         },
         {
           type: 'separator',
@@ -164,17 +179,17 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
         {
           label: 'Zoom In',
           accelerator: 'Cmd+=',
-          click: (item, win) => sendMessage(win, 'sqlectron:zoom-in'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:zoom-in'),
         },
         {
           label: 'Zoom Out',
           accelerator: 'Cmd+-',
-          click: (item, win) => sendMessage(win, 'sqlectron:zoom-out'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:zoom-out'),
         },
         {
           label: 'Reset Zoom',
           accelerator: 'Cmd+0',
-          click: (item, win) => sendMessage(win, 'sqlectron:zoom-reset'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:zoom-reset'),
         },
       ],
     },
@@ -184,12 +199,14 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
         {
           label: 'Search databases',
           accelerator: 'Shift+Cmd+9',
-          click: (item, win) => sendMessage(win, 'sqlectron:toggle-database-search'),
+          click: (item, win) =>
+            sendMessage(win as BrowserWindow, 'sqlectron:toggle-database-search'),
         },
         {
           label: 'Search database objects',
           accelerator: 'Cmd+9',
-          click: (item, win) => sendMessage(win, 'sqlectron:toggle-database-objects-search'),
+          click: (item, win) =>
+            sendMessage(win as BrowserWindow, 'sqlectron:toggle-database-objects-search'),
         },
       ],
     },
@@ -199,11 +216,13 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
         {
           label: 'Minimize',
           accelerator: 'Cmd+M',
+          // @ts-ignore
           selector: 'performMiniaturize:',
         },
         {
           label: 'Close',
           accelerator: 'Cmd+Shift+W',
+          // @ts-ignore
           selector: 'performClose:',
         },
         {
@@ -211,6 +230,7 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
         },
         {
           label: 'Bring All to Front',
+          // @ts-ignore
           selector: 'arrangeInFront:',
         },
       ],
@@ -220,13 +240,16 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
       submenu: [
         {
           label: 'Report Issue',
-          click: () => shell.openExternal(appConfig.bugs),
+          click: () => shell.openExternal(appConfig.bugs as string),
         },
       ],
     },
   ];
 }
 
-export function buildTemplateDockMenu(app, buildNewWindow) {
+export function buildTemplateDockMenu(
+  app: App,
+  buildNewWindow: BuildWindow,
+): Array<MenuItemConstructorOptions> {
   return [{ label: 'New Window', click: () => buildNewWindow(app) }];
 }

--- a/src/browser/menu/index.ts
+++ b/src/browser/menu/index.ts
@@ -1,4 +1,5 @@
-import { Menu } from 'electron';
+import { Menu, App } from 'electron';
+import { Config } from '../../common/types/config';
 import * as darwin from './darwin';
 import * as linux from './linux';
 import * as win32 from './win32';
@@ -9,7 +10,9 @@ const menus = {
   win32,
 };
 
-export function attachMenuToWindow(app, buildNewWindow, appConfig) {
+type BuildWindow = (app: App) => void; // eslint-disable-line no-unused-vars
+
+export function attachMenuToWindow(app: App, buildNewWindow: BuildWindow, appConfig: Config): void {
   const template = menus[process.platform].buildTemplate(app, buildNewWindow, appConfig);
   const menu = Menu.buildFromTemplate(template);
   Menu.setApplicationMenu(menu);

--- a/src/browser/menu/index.ts
+++ b/src/browser/menu/index.ts
@@ -1,5 +1,6 @@
 import { Menu, App } from 'electron';
 import { Config } from '../../common/types/config';
+import { BuildWindow } from '../../common/types/menu';
 import * as darwin from './darwin';
 import * as linux from './linux';
 import * as win32 from './win32';
@@ -9,8 +10,6 @@ const menus = {
   linux,
   win32,
 };
-
-type BuildWindow = (app: App) => void; // eslint-disable-line no-unused-vars
 
 export function attachMenuToWindow(app: App, buildNewWindow: BuildWindow, appConfig: Config): void {
   const template = menus[process.platform].buildTemplate(app, buildNewWindow, appConfig);

--- a/src/browser/menu/linux.ts
+++ b/src/browser/menu/linux.ts
@@ -1,14 +1,13 @@
 import { shell } from 'electron';
 import { BrowserWindow, App, MenuItem, MenuItemConstructorOptions } from 'electron';
 import { Config } from '../../common/types/config';
+import { BuildWindow } from '../../common/types/menu';
 
 function sendMessage(win: BrowserWindow, message: string) {
   if (win) {
     win.webContents.send(message);
   }
 }
-
-type BuildWindow = (app: App) => void; // eslint-disable-line no-unused-vars
 
 export function buildTemplate(
   app: App,

--- a/src/browser/menu/linux.ts
+++ b/src/browser/menu/linux.ts
@@ -1,12 +1,20 @@
 import { shell } from 'electron';
+import { BrowserWindow, App, MenuItem, MenuItemConstructorOptions } from 'electron';
+import { Config } from '../../common/types/config';
 
-function sendMessage(win, message) {
+function sendMessage(win: BrowserWindow, message: string) {
   if (win) {
     win.webContents.send(message);
   }
 }
 
-export function buildTemplate(app, buildNewWindow, appConfig) {
+type BuildWindow = (app: App) => void; // eslint-disable-line no-unused-vars
+
+export function buildTemplate(
+  app: App,
+  buildNewWindow: BuildWindow,
+  appConfig: Config,
+): Array<MenuItemConstructorOptions | MenuItem> {
   return [
     {
       label: 'File',
@@ -19,12 +27,12 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
         {
           label: 'New Tab',
           accelerator: 'Ctrl+T',
-          click: (item, win) => sendMessage(win, 'sqlectron:new-tab'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:new-tab'),
         },
         {
           label: 'Close Tab',
           accelerator: 'Ctrl+W',
-          click: (item, win) => sendMessage(win, 'sqlectron:close-tab'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:close-tab'),
         },
         {
           type: 'separator',
@@ -32,17 +40,17 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
         {
           label: 'Save Query',
           accelerator: 'Ctrl+S',
-          click: (item, win) => sendMessage(win, 'sqlectron:save-query'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:save-query'),
         },
         {
           label: 'Save Query As',
           accelerator: 'Shift+Ctrl+S',
-          click: (item, win) => sendMessage(win, 'sqlectron:save-query-as'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:save-query-as'),
         },
         {
           label: 'Open Query',
           accelerator: 'Ctrl+O',
-          click: (item, win) => sendMessage(win, 'sqlectron:open-query'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:open-query'),
         },
         {
           type: 'separator',
@@ -60,17 +68,17 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
         {
           label: 'Execute',
           accelerator: 'Ctrl+Enter',
-          click: (item, win) => sendMessage(win, 'sqlectron:query-execute'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:query-execute'),
         },
         {
           label: 'Execute',
           accelerator: 'Ctrl+R',
-          click: (item, win) => sendMessage(win, 'sqlectron:query-execute'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:query-execute'),
         },
         {
           label: 'Focus Query Editor',
           accelerator: 'Shift+Ctrl+0',
-          click: (item, win) => sendMessage(win, 'sqlectron:query-focus'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:query-focus'),
         },
       ],
     },
@@ -80,12 +88,12 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
         {
           label: 'Undo',
           accelerator: 'Ctrl+Z',
-          selector: 'undo:',
+          role: 'undo',
         },
         {
           label: 'Redo',
           accelerator: 'Shift+Ctrl+Z',
-          selector: 'redo:',
+          role: 'redo',
         },
         {
           type: 'separator',
@@ -93,22 +101,22 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
         {
           label: 'Cut',
           accelerator: 'Ctrl+X',
-          selector: 'cut:',
+          role: 'cut',
         },
         {
           label: 'Copy',
           accelerator: 'Ctrl+C',
-          selector: 'copy:',
+          role: 'copy',
         },
         {
           label: 'Paste',
           accelerator: 'Ctrl+V',
-          selector: 'paste:',
+          role: 'paste',
         },
         {
           label: 'Select All',
           accelerator: 'Ctrl+A',
-          selector: 'selectAll:',
+          role: 'selectAll',
         },
       ],
     },
@@ -118,12 +126,12 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
         {
           label: 'Reload',
           accelerator: 'Ctrl+Shift+R',
-          click: (item, win) => win.webContents.reloadIgnoringCache(),
+          click: (item, win) => (win as BrowserWindow).webContents.reloadIgnoringCache(),
         },
         {
           label: 'Toggle DevTools',
           accelerator: 'Alt+Ctrl+I',
-          click: (item, win) => win.toggleDevTools(),
+          click: (item, win) => (win as BrowserWindow).webContents.toggleDevTools(),
         },
         {
           type: 'separator',
@@ -131,17 +139,17 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
         {
           label: 'Zoom In',
           accelerator: 'Ctrl+=',
-          click: (item, win) => sendMessage(win, 'sqlectron:zoom-in'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:zoom-in'),
         },
         {
           label: 'Zoom Out',
           accelerator: 'Ctrl+-',
-          click: (item, win) => sendMessage(win, 'sqlectron:zoom-out'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:zoom-out'),
         },
         {
           label: 'Reset Zoom',
           accelerator: 'Ctrl+0',
-          click: (item, win) => sendMessage(win, 'sqlectron:zoom-reset'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:zoom-reset'),
         },
       ],
     },
@@ -151,12 +159,14 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
         {
           label: 'Search databases',
           accelerator: 'Shift+Ctrl+9',
-          click: (item, win) => sendMessage(win, 'sqlectron:toggle-database-search'),
+          click: (item, win) =>
+            sendMessage(win as BrowserWindow, 'sqlectron:toggle-database-search'),
         },
         {
           label: 'Search database objects',
           accelerator: 'Ctrl+9',
-          click: (item, win) => sendMessage(win, 'sqlectron:toggle-database-objects-search'),
+          click: (item, win) =>
+            sendMessage(win as BrowserWindow, 'sqlectron:toggle-database-objects-search'),
         },
       ],
     },
@@ -165,11 +175,11 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
       submenu: [
         {
           label: 'Report Issue',
-          click: () => shell.openExternal(appConfig.bugs),
+          click: () => shell.openExternal(appConfig.bugs as string),
         },
         {
           label: `About ${appConfig.name}`,
-          click: () => shell.openExternal(appConfig.homepage),
+          click: () => shell.openExternal(appConfig.homepage as string),
         },
       ],
     },

--- a/src/browser/menu/win32.ts
+++ b/src/browser/menu/win32.ts
@@ -1,14 +1,13 @@
 import { shell } from 'electron';
 import { BrowserWindow, App, MenuItem, MenuItemConstructorOptions } from 'electron';
 import { Config } from '../../common/types/config';
+import { BuildWindow } from '../../common/types/menu';
 
 function sendMessage(win: BrowserWindow, message: string) {
   if (win) {
     win.webContents.send(message);
   }
 }
-
-type BuildWindow = (app: App) => void; // eslint-disable-line no-unused-vars
 
 export function buildTemplate(
   app: App,

--- a/src/browser/menu/win32.ts
+++ b/src/browser/menu/win32.ts
@@ -1,12 +1,20 @@
 import { shell } from 'electron';
+import { BrowserWindow, App, MenuItem, MenuItemConstructorOptions } from 'electron';
+import { Config } from '../../common/types/config';
 
-function sendMessage(win, message) {
+function sendMessage(win: BrowserWindow, message: string) {
   if (win) {
     win.webContents.send(message);
   }
 }
 
-export function buildTemplate(app, buildNewWindow, appConfig) {
+type BuildWindow = (app: App) => void; // eslint-disable-line no-unused-vars
+
+export function buildTemplate(
+  app: App,
+  buildNewWindow: BuildWindow,
+  appConfig: Config,
+): Array<MenuItemConstructorOptions | MenuItem> {
   return [
     {
       label: 'File',
@@ -19,12 +27,12 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
         {
           label: 'New Tab',
           accelerator: 'Ctrl+T',
-          click: (item, win) => sendMessage(win, 'sqlectron:new-tab'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:new-tab'),
         },
         {
           label: 'Close Tab',
           accelerator: 'Ctrl+W',
-          click: (item, win) => sendMessage(win, 'sqlectron:close-tab'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:close-tab'),
         },
         {
           type: 'separator',
@@ -32,17 +40,17 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
         {
           label: 'Save Query',
           accelerator: 'Ctrl+S',
-          click: (item, win) => sendMessage(win, 'sqlectron:save-query'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:save-query'),
         },
         {
           label: 'Save Query As',
           accelerator: 'Ctrl+Shift+S',
-          click: (item, win) => sendMessage(win, 'sqlectron:save-query-as'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:save-query-as'),
         },
         {
           label: 'Open Query',
           accelerator: 'Ctrl+O',
-          click: (item, win) => sendMessage(win, 'sqlectron:open-query'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:open-query'),
         },
         {
           type: 'separator',
@@ -60,17 +68,17 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
         {
           label: 'Execute',
           accelerator: 'Ctrl+Enter',
-          click: (item, win) => sendMessage(win, 'sqlectron:query-execute'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:query-execute'),
         },
         {
           label: 'Execute',
           accelerator: 'Ctrl+R',
-          click: (item, win) => sendMessage(win, 'sqlectron:query-execute'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:query-execute'),
         },
         {
           label: 'Focus Query Editor',
           accelerator: 'Shift+Ctrl+0',
-          click: (item, win) => sendMessage(win, 'sqlectron:query-focus'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:query-focus'),
         },
       ],
     },
@@ -80,12 +88,12 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
         {
           label: 'Undo',
           accelerator: 'Ctrl+Z',
-          selector: 'undo:',
+          role: 'undo',
         },
         {
           label: 'Redo',
           accelerator: 'Shift+Ctrl+Z',
-          selector: 'redo:',
+          role: 'redo',
         },
         {
           type: 'separator',
@@ -93,22 +101,22 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
         {
           label: 'Cut',
           accelerator: 'Ctrl+X',
-          selector: 'cut:',
+          role: 'cut',
         },
         {
           label: 'Copy',
           accelerator: 'Ctrl+C',
-          selector: 'copy:',
+          role: 'copy',
         },
         {
           label: 'Paste',
           accelerator: 'Ctrl+V',
-          selector: 'paste:',
+          role: 'paste',
         },
         {
           label: 'Select All',
           accelerator: 'Ctrl+A',
-          selector: 'selectAll:',
+          role: 'selectAll',
         },
       ],
     },
@@ -118,12 +126,12 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
         {
           label: 'Reload',
           accelerator: 'Ctrl+Shift+R',
-          click: (item, win) => win.webContents.reloadIgnoringCache(),
+          click: (item, win) => (win as BrowserWindow).webContents.reloadIgnoringCache(),
         },
         {
           label: 'Toggle DevTools',
           accelerator: 'Alt+Ctrl+I',
-          click: (item, win) => win.toggleDevTools(),
+          click: (item, win) => (win as BrowserWindow).webContents.toggleDevTools(),
         },
         {
           type: 'separator',
@@ -131,17 +139,17 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
         {
           label: 'Zoom In',
           accelerator: 'Ctrl+=',
-          click: (item, win) => sendMessage(win, 'sqlectron:zoom-in'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:zoom-in'),
         },
         {
           label: 'Zoom Out',
           accelerator: 'Ctrl+-',
-          click: (item, win) => sendMessage(win, 'sqlectron:zoom-out'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:zoom-out'),
         },
         {
           label: 'Reset Zoom',
           accelerator: 'Ctrl+0',
-          click: (item, win) => sendMessage(win, 'sqlectron:zoom-reset'),
+          click: (item, win) => sendMessage(win as BrowserWindow, 'sqlectron:zoom-reset'),
         },
       ],
     },
@@ -151,12 +159,14 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
         {
           label: 'Search databases',
           accelerator: 'Shift+Ctrl+9',
-          click: (item, win) => sendMessage(win, 'sqlectron:toggle-database-search'),
+          click: (item, win) =>
+            sendMessage(win as BrowserWindow, 'sqlectron:toggle-database-search'),
         },
         {
           label: 'Search database objects',
           accelerator: 'Ctrl+9',
-          click: (item, win) => sendMessage(win, 'sqlectron:toggle-database-objects-search'),
+          click: (item, win) =>
+            sendMessage(win as BrowserWindow, 'sqlectron:toggle-database-objects-search'),
         },
       ],
     },
@@ -165,11 +175,11 @@ export function buildTemplate(app, buildNewWindow, appConfig) {
       submenu: [
         {
           label: 'Report Issue',
-          click: () => shell.openExternal(appConfig.bugs),
+          click: () => shell.openExternal(appConfig.bugs as string),
         },
         {
           label: `About ${appConfig.name}`,
-          click: () => shell.openExternal(appConfig.homepage),
+          click: () => shell.openExternal(appConfig.homepage as string),
         },
       ],
     },

--- a/src/browser/update-checker.ts
+++ b/src/browser/update-checker.ts
@@ -1,13 +1,15 @@
 import axios from 'axios';
+import { BrowserWindow } from 'electron';
+import { Config } from '../common/types/config';
 import createLogger from './logger';
 
 const logger = createLogger('gh-update-checker');
 
-export async function check(mainWindow, appConfig) {
+export async function check(mainWindow: BrowserWindow, appConfig: Config): Promise<void> {
   const currentVersion = `v${appConfig.version}`;
   logger.debug('current version %s', currentVersion);
 
-  const repo = appConfig.repository.url.replace('https://github.com/', '');
+  const repo = appConfig.repository?.url.replace('https://github.com/', '');
   const latestReleaseURL = `https://api.github.com/repos/${repo}/releases/latest`;
   const response = await axios.get(latestReleaseURL);
 

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -21,6 +21,11 @@ export interface Config {
   // Fields attached from package.json
   name: string;
   version: string;
+  homepage?: string;
+  bugs?: string;
+  repository?: {
+    url: string;
+  };
   // Fields attached from cli args
   devMode?: boolean;
   printVersion?: boolean;

--- a/src/common/types/menu.ts
+++ b/src/common/types/menu.ts
@@ -1,0 +1,3 @@
+import { App } from 'electron';
+
+export type BuildWindow = (app: App) => void; // eslint-disable-line no-unused-vars

--- a/test/browser/test.config.ts
+++ b/test/browser/test.config.ts
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { config } from '../../src/browser/core';
 import { readJSONFile } from '../../src/browser/core/utils';
 import { decrypt } from '../../src/browser/core/crypto';
+import { EncryptedPassword } from '../../src/common/types/server';
 import utilsStub from './utils-stub';
 
 const cryptoSecret = 'CHK`Ya91Hs{me!^8ndwPPaPPxwQ}`';
@@ -29,19 +30,19 @@ describe('config', () => {
         const expectedServer = expected.servers[i];
         const actualServer = fixtureAfter.servers[i];
         if (expectedServer.password) {
-          expect(decrypt(expected.servers[i].password, cryptoSecret)).to.equal(
-            decrypt(actualServer.password, cryptoSecret),
+          expect(decrypt(expected.servers[i].password as EncryptedPassword, cryptoSecret)).to.equal(
+            decrypt(actualServer.password as EncryptedPassword, cryptoSecret),
           );
-          delete expectedServer.password;
-          delete actualServer.password;
+          expectedServer.password = '';
+          actualServer.password = '';
         }
 
         if (expectedServer.ssh && expectedServer.ssh.password) {
-          expect(decrypt(expectedServer.ssh.password, cryptoSecret)).to.equal(
-            decrypt(actualServer.ssh.password, cryptoSecret),
+          expect(decrypt(expectedServer.ssh.password as EncryptedPassword, cryptoSecret)).to.equal(
+            decrypt(actualServer.ssh!.password as EncryptedPassword, cryptoSecret),
           );
-          delete expectedServer.ssh.password;
-          delete actualServer.ssh.password;
+          expectedServer.ssh.password = '';
+          actualServer.ssh!.password = '';
         }
 
         expect(expectedServer).to.eql(actualServer);

--- a/test/browser/test.servers.ts
+++ b/test/browser/test.servers.ts
@@ -27,16 +27,16 @@ describe('servers', () => {
       // DO NOT decrypt assert data
       const encryptedServer1 = fixture.servers.find(
         (srv) => srv.id === '65f36ca9-331f-43b3-ab38-3f5556fd65ce',
-      );
+      ) as Server;
       encryptedServer1.encrypted = true;
       encryptedServer1.password = 'fa1d88ee82bd4439';
 
       const encryptedServer2 = fixture.servers.find(
         (srv) => srv.id === '179d7c6e-2d7c-4c86-b203-d901b7dfea77',
-      );
+      ) as Server;
       encryptedServer2.encrypted = true;
       encryptedServer2.password = 'fa1d88ee82bd4439';
-      encryptedServer2.ssh.password = 'fa1d88ee82bd4439';
+      encryptedServer2.ssh!.password = 'fa1d88ee82bd4439';
 
       expect(result).to.eql(fixture.servers);
     });
@@ -45,10 +45,11 @@ describe('servers', () => {
   describe('.add', () => {
     it('should add new server', async () => {
       const configBefore = await loadConfig();
-      const newServer = {
+      const newServer: Server = {
+        id: '',
         name: 'My New Mysql Server',
         client: 'mysql',
-        ssl: true,
+        ssl: false,
         host: '10.10.10.15',
         port: 3306,
         database: 'authentication',
@@ -57,7 +58,7 @@ describe('servers', () => {
       };
       const createdServer = await servers.add(newServer, cryptoSecret);
       expect(createdServer).to.have.property('id');
-      delete createdServer.id;
+      createdServer.id = '';
       assertPassword(newServer, createdServer);
       expect(createdServer).to.eql(newServer);
 
@@ -67,10 +68,11 @@ describe('servers', () => {
 
     it('should add new server with ssh', async () => {
       const configBefore = await loadConfig();
-      const newServer = {
+      const newServer: Server = {
+        id: '',
         name: 'My New Mysql Server',
         client: 'mysql',
-        ssl: true,
+        ssl: false,
         host: '10.10.10.15',
         port: 3306,
         database: 'authentication',
@@ -81,12 +83,16 @@ describe('servers', () => {
           port: 22,
           user: 'root',
           privateKey: '~/.ssh/id_rsa',
+          password: {
+            ivText: 'wGf6X9T+QSygOHqtgQPlcA==',
+            encryptedText: '0LySDs9WPAvwSS9Qv+W3/A==',
+          },
           privateKeyWithPassphrase: true,
         },
       };
       const createdServer = await servers.add(newServer, cryptoSecret);
       expect(createdServer).to.have.property('id');
-      delete createdServer.id;
+      createdServer.id = '';
       assertPassword(newServer, createdServer);
       expect(createdServer).to.eql(newServer);
 
@@ -99,7 +105,7 @@ describe('servers', () => {
     it('should update existing server', async () => {
       const id = 'ed2d52a7-d8ff-4fdd-897a-7033dee598f4';
       const configBefore = await loadConfig();
-      const serverToUpdate = {
+      const serverToUpdate: Server = {
         id,
         name: 'mysql-vm',
         client: 'mysql',
@@ -123,7 +129,7 @@ describe('servers', () => {
     it('should upgrade oldstyle encrypted password', async () => {
       const id = '65f36ca9-331f-43b3-ab38-3f5556fd65ce';
       const configBefore = await loadConfig();
-      const serverToUpdate = {
+      const serverToUpdate: Server = {
         id,
         name: 'mysql-vm',
         client: 'mysql',
@@ -149,7 +155,7 @@ describe('servers', () => {
   it('should not update password when password is already encrypted', async () => {
     const id = '440d4fef-6fc8-4e53-ba84-f89c91d9c542';
     const configBefore = await loadConfig();
-    const serverToUpdate = {
+    const serverToUpdate: Server = {
       id,
       name: 'mysql-vm',
       client: 'mysql',
@@ -179,7 +185,8 @@ describe('servers', () => {
     describe('given is a new server', () => {
       it('should add the new server', async () => {
         const configBefore = await loadConfig();
-        const newServer = {
+        const newServer: Server = {
+          id: '',
           name: 'My New Mysql Server',
           client: 'mysql',
           ssl: false,
@@ -191,7 +198,7 @@ describe('servers', () => {
         };
         const createdServer = await servers.addOrUpdate(newServer, cryptoSecret);
         expect(createdServer).to.have.property('id');
-        delete createdServer.id;
+        createdServer.id = '';
         assertPassword(newServer, createdServer);
         expect(createdServer).to.eql(newServer);
 
@@ -204,7 +211,7 @@ describe('servers', () => {
       it('should update this existing server', async () => {
         const configBefore = await loadConfig();
         const id = 'ed2d52a7-d8ff-4fdd-897a-7033dee598f4';
-        const serverToUpdate = {
+        const serverToUpdate: Server = {
           id,
           name: 'mysql-vm',
           client: 'mysql',
@@ -292,7 +299,8 @@ describe('servers', () => {
     });
 
     it('should decrypt old style password', () => {
-      const encryptedServer = {
+      const encryptedServer: Server = {
+        id: '',
         name: 'mysql-vm',
         client: 'mysql',
         ssl: false,
@@ -311,7 +319,8 @@ describe('servers', () => {
     });
 
     it('should decrypt old style password for ssh', () => {
-      const encryptedServer = {
+      const encryptedServer: Server = {
+        id: '',
         name: 'mysql-vm',
         client: 'mysql',
         ssl: false,
@@ -319,20 +328,28 @@ describe('servers', () => {
         port: 3306,
         database: 'mydb',
         user: 'usr',
+        password: {
+          ivText: 'wGf6X9T+QSygOHqtgQPlcA==',
+          encryptedText: '0LySDs9WPAvwSS9Qv+W3/A==',
+        },
         encrypted: true,
         ssh: {
+          user: 'usr',
+          host: 'localhost',
+          port: 22,
           password: 'fa1d88ee82bd4439',
         },
       };
       const decryptedServer = servers.decryptSecrects(encryptedServer, cryptoSecret);
 
       encryptedServer.encrypted = false;
-      encryptedServer.ssh.password = 'password';
+      encryptedServer.ssh!.password = 'password';
       expect(decryptedServer).to.eql(encryptedServer);
     });
 
     it('should do nothing for unencrypted server', () => {
-      const encryptedServer = {
+      const encryptedServer: Server = {
+        id: '',
         name: 'mysql-vm',
         client: 'mysql',
         ssl: false,

--- a/test/browser/test.servers.ts
+++ b/test/browser/test.servers.ts
@@ -343,6 +343,7 @@ describe('servers', () => {
       const decryptedServer = servers.decryptSecrects(encryptedServer, cryptoSecret);
 
       encryptedServer.encrypted = false;
+      encryptedServer.password = 'password';
       encryptedServer.ssh!.password = 'password';
       expect(decryptedServer).to.eql(encryptedServer);
     });

--- a/test/browser/utils-stub.ts
+++ b/test/browser/utils-stub.ts
@@ -10,7 +10,7 @@ export default {
   TMP_FIXTURE_PATH,
 
   getConfigPath: {
-    install({ copyFixtureToTemp }) {
+    install({ copyFixtureToTemp }: { copyFixtureToTemp?: boolean }): void {
       const sandbox = sinon.createSandbox();
 
       beforeEach(async () => {

--- a/test/browser/validators/test.server.ts
+++ b/test/browser/validators/test.server.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { validate, validateUniqueId } from '../../../src/browser/core/validators/server';
+import { Server } from '../../../src/common/types/server';
 
 describe('validators/server', () => {
   describe('validate', () => {
@@ -90,7 +91,7 @@ describe('validators/server', () => {
       },
     ].forEach((server, idx) => {
       it(`should validate server ${idx}`, (done) => {
-        validate(server)
+        validate(server as Server)
           .then(() => done())
           .catch((err) => done(err));
       });
@@ -108,7 +109,7 @@ describe('validators/server', () => {
           password: 'password',
           database: 'company',
           ssl: false,
-        };
+        } as Server;
         validate(server)
           .then(() => done())
           .catch((err) => done(err));
@@ -126,7 +127,7 @@ describe('validators/server', () => {
         password: 'password',
         database: 'company',
         ssl: false,
-      };
+      } as Server;
       validate(server)
         .then(() => done(new Error('should have thrown error')))
         .catch((err) => {
@@ -150,7 +151,7 @@ describe('validators/server', () => {
     it('should fail when serverId is found', () => {
       expect(
         validateUniqueId(
-          [{ id: '1c7cdae9-6065-46fa-a7d0-b89ccff78703' }],
+          [{ id: '1c7cdae9-6065-46fa-a7d0-b89ccff78703' } as Server],
           '1c7cdae9-6065-46fa-a7d0-b89ccff78703',
         ),
       ).to.eql(false);

--- a/test/e2e/helper.ts
+++ b/test/e2e/helper.ts
@@ -1,12 +1,16 @@
 import path from 'path';
 import { expect } from 'chai';
 import electronPath = require('electron');
-import { electron } from 'playwright-electron';
+import { electron, ElectronApplication, Page } from 'playwright-electron';
 
-const startApp = async ({ sqlectronHome }) => {
+const startApp = async ({
+  sqlectronHome,
+}: {
+  sqlectronHome: string;
+}): Promise<{ app: ElectronApplication; mainWindow: Page }> => {
   // Start Electron application
   // @ts-ignore
-  const app = await electron.launch(electronPath, {
+  const app: ElectronApplication = await electron.launch(electronPath, {
     path: electronPath,
     args:
       process.env.DEV_MODE === 'true'
@@ -24,14 +28,14 @@ const startApp = async ({ sqlectronHome }) => {
   return { app, mainWindow };
 };
 
-const endApp = async (app) => {
+const endApp = async (app: ElectronApplication): Promise<void> => {
   // After each test close Electron application.
   await app.close();
 };
 
-const wait = (time) => new Promise((resolve) => setTimeout(resolve, time));
+const wait = (time: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, time));
 
-const getAppPage = async (app, { waitAppLoad = true } = {}) => {
+const getAppPage = async (app: ElectronApplication, { waitAppLoad = true } = {}): Promise<Page> => {
   // Attempt though 25 times waiting 1s between each attempt
   // to get the application page
   for (let attempt = 0; attempt < 25; attempt++) {
@@ -55,8 +59,8 @@ const getAppPage = async (app, { waitAppLoad = true } = {}) => {
   throw new Error('Could not find application page');
 };
 
-const expectToEqualText = async (page, selector, text) => {
-  expect(await page.$eval(selector, (node) => node.innerText)).to.be.equal(text);
+const expectToEqualText = async (page: Page, selector: string, text: string): Promise<void> => {
+  expect(await page.$eval(selector, (node: HTMLElement) => node.innerText)).to.be.equal(text);
 };
 
 export default {


### PR DESCRIPTION
I noticed that the linter wasn't detecting many typing issues for `src/browser` code because the `@typescript-eslint/explicit-module-boundary-types` rule was turned off. 

PS: That same rule still turned off for `src/renderer` because turning it on now probably would require converting all files to typescript, or at least have a bunch of lint issues to be fixed right now. Leaving it for when/if we decide to convert those files to typescript (new files we should use typescript, but I don't mind keeping old ones in JS for now).