### PR TITLE
Fix error on starting sqlectron with no config file

### DIFF
--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -11,7 +11,7 @@ import defaultsDeep from 'lodash.defaultsdeep';
 import * as sqlectron from './core';
 import { Config } from '../common/types/config';
 
-let config;
+let config: Config;
 
 const cryptoSecret = 'j[F6Y6NoWT}+YG|4c|-<89:ByJ83-9Aj?O8>$Zk/[WFk_~gFbg7<wm+*V|A{xQZ,';
 
@@ -46,7 +46,7 @@ export function getConfig(cleanCache = false): Config {
     log: {
       console: isDev,
       file: false,
-      level: appConfig.log.level || (process.env.DEBUG ? 'debug' : 'error'),
+      level: (appConfig.log || {}).level || (process.env.DEBUG ? 'debug' : 'error'),
       path: configPath.replace('.json', '.log'),
     },
   };

--- a/src/browser/core/config.ts
+++ b/src/browser/core/config.ts
@@ -1,9 +1,11 @@
 import { v4 as uuidv4 } from 'uuid';
 import * as utils from './utils';
 import * as crypto from './crypto';
-import { Config } from '../../common/types/config';
+import { Config, ConfigFile } from '../../common/types/config';
 
-const EMPTY_CONFIG = <Config>{};
+const EMPTY_CONFIG = <ConfigFile>{
+  servers: [],
+};
 
 function sanitizeServer(server, cryptoSecret) {
   const srv = { ...server };
@@ -57,7 +59,7 @@ export async function prepare(cryptoSecret: string): Promise<void> {
     await utils.writeJSONFile(filename, EMPTY_CONFIG);
   }
 
-  const result = await utils.readJSONFile(filename);
+  const result = await utils.readJSONFile<ConfigFile>(filename);
 
   result.servers = sanitizeServers(result, cryptoSecret);
 
@@ -77,7 +79,7 @@ export function prepareSync(cryptoSecret: string): void {
     utils.writeJSONFileSync(filename, EMPTY_CONFIG);
   }
 
-  const result = utils.readJSONFileSync(filename);
+  const result = utils.readJSONFileSync<ConfigFile>(filename);
 
   result.servers = sanitizeServers(result, cryptoSecret);
 
@@ -99,7 +101,7 @@ export function get(): Promise<Config> {
   return utils.readJSONFile(filename);
 }
 
-export function getSync(): Config {
+export function getSync(): ConfigFile {
   const filename = utils.getConfigPath();
   return utils.readJSONFileSync(filename);
 }

--- a/src/browser/core/utils.ts
+++ b/src/browser/core/utils.ts
@@ -5,7 +5,6 @@ import mkdirp from 'mkdirp';
 import envPaths from 'env-paths';
 
 import { readFile, resolveHomePathToAbsolute } from 'sqlectron-db-core/utils';
-import { Config } from '../../common/types/config';
 
 export {
   createCancelablePromise,
@@ -63,19 +62,19 @@ export function writeFile(filename: string, data: string): Promise<void> {
   });
 }
 
-export function writeJSONFile(filename: string, data: Config): Promise<void> {
+export function writeJSONFile<T>(filename: string, data: T): Promise<void> {
   return writeFile(filename, JSON.stringify(data, null, 2));
 }
 
-export function writeJSONFileSync(filename: string, data: Config): void {
+export function writeJSONFileSync<T>(filename: string, data: T): void {
   return fs.writeFileSync(filename, JSON.stringify(data, null, 2));
 }
 
-export function readJSONFile(filename: string): Promise<Config> {
+export function readJSONFile<T>(filename: string): Promise<T> {
   return readFile(filename).then((data) => JSON.parse(data));
 }
 
-export function readJSONFileSync(filename: string): Config {
+export function readJSONFileSync<T>(filename: string): T {
   const filePath = resolveHomePathToAbsolute(filename);
   const data = fs.readFileSync(path.resolve(filePath), { encoding: 'utf-8' });
   return JSON.parse(data);

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -1,5 +1,10 @@
 import { Server } from './server';
 
+/**
+ * This interface documents the sqlectron.json file. The only thing guaranteed to
+ * exist is the `servers` key/value pair (instantiated to empty array). The rest
+ * will only exist if the user goes into the Settings modal and hits save.
+ */
 export interface ConfigFile {
   log?: {
     console: boolean;
@@ -20,6 +25,11 @@ export interface ConfigFile {
   customFont?: string;
 }
 
+/**
+ * This interface documents the instantiated Config object that is fed through
+ * sqlectron application. This takes the config loaded by the file, adds in application
+ * defaults and fields from package.json, and then utilizes that throughout.
+ */
 export interface Config {
   log: {
     console: boolean;

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -1,5 +1,25 @@
 import { Server } from './server';
 
+export interface ConfigFile {
+  log?: {
+    console: boolean;
+    file: boolean;
+    level: string;
+    path: string;
+  };
+  zoomFactor?: number;
+  limitQueryDefaultSelectTop?: number;
+  servers: Array<Server>;
+  enabledAutoComplete?: boolean;
+  enabledLiveAutoComplete?: boolean;
+  // queries: Object;
+  enabledDarkTheme?: boolean;
+  disabledOpenAnimation?: boolean;
+  csvDelimiter?: string;
+  connectionsAsList?: boolean;
+  customFont?: string;
+}
+
 export interface Config {
   log: {
     console: boolean;

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -1,20 +1,22 @@
 import { Server } from './server';
 
+interface LogOptions {
+  console: boolean;
+  file: boolean;
+  level: string;
+  path: string;
+}
+
 /**
  * This interface documents the sqlectron.json file. The only thing guaranteed to
  * exist is the `servers` key/value pair (instantiated to empty array). The rest
  * will only exist if the user goes into the Settings modal and hits save.
  */
 export interface ConfigFile {
-  log?: {
-    console: boolean;
-    file: boolean;
-    level: string;
-    path: string;
-  };
+  servers: Array<Server>;
+  log?: LogOptions;
   zoomFactor?: number;
   limitQueryDefaultSelectTop?: number;
-  servers: Array<Server>;
   enabledAutoComplete?: boolean;
   enabledLiveAutoComplete?: boolean;
   // queries: Object;
@@ -30,16 +32,10 @@ export interface ConfigFile {
  * sqlectron application. This takes the config loaded by the file, adds in application
  * defaults and fields from package.json, and then utilizes that throughout.
  */
-export interface Config {
-  log: {
-    console: boolean;
-    file: boolean;
-    level: string;
-    path: string;
-  };
+export interface Config extends ConfigFile {
+  log: LogOptions;
   zoomFactor: number;
   limitQueryDefaultSelectTop: number;
-  servers: Array<Server>;
   enabledAutoComplete: boolean;
   enabledLiveAutoComplete: boolean;
   // queries: Object;

--- a/test/browser/test.config.ts
+++ b/test/browser/test.config.ts
@@ -5,6 +5,7 @@ import { readJSONFile } from '../../src/browser/core/utils';
 import { decrypt } from '../../src/browser/core/crypto';
 import { EncryptedPassword } from '../../src/common/types/server';
 import utilsStub from './utils-stub';
+import { ConfigFile } from '../../src/common/types/config';
 
 const cryptoSecret = 'CHK`Ya91Hs{me!^8ndwPPaPPxwQ}`';
 
@@ -21,7 +22,7 @@ describe('config', () => {
 
       expect(findItem(fixtureBefore)).to.not.have.property('id');
       expect(findItem(fixtureAfter)).to.have.property('id');
-      const expected = await readJSONFile(
+      const expected = await readJSONFile<ConfigFile>(
         path.join(__dirname, '../fixtures/browser/sqlectron.prepared.json'),
       );
       expect(fixtureAfter.servers).to.be.same.length(expected.servers.length);
@@ -51,6 +52,6 @@ describe('config', () => {
   });
 
   function loadConfig() {
-    return readJSONFile(utilsStub.TMP_FIXTURE_PATH);
+    return readJSONFile<ConfigFile>(utilsStub.TMP_FIXTURE_PATH);
   }
 });

--- a/test/browser/test.servers.ts
+++ b/test/browser/test.servers.ts
@@ -4,6 +4,7 @@ import { readJSONFile } from '../../src/browser/core/utils';
 import * as crypto from '../../src/browser/core/crypto';
 import { Server } from '../../src/common/types/server';
 import utilsStub from './utils-stub';
+import { Config } from '../../src/common/types/config';
 
 const cryptoSecret = 'CHK`Ya91Hs{me!^8ndwPPaPPxwQ}`';
 
@@ -365,6 +366,6 @@ describe('servers', () => {
   });
 
   function loadConfig() {
-    return readJSONFile(utilsStub.TMP_FIXTURE_PATH);
+    return readJSONFile<Config>(utilsStub.TMP_FIXTURE_PATH);
   }
 });


### PR DESCRIPTION
Closes #596

When sqlectron is started for the first time with an empty config file, a number of errors are thrown, namely that:
* servers does not exist, throwing an "map on undefined" error
* log.level does not exist, throwing an "level on undefined" error

To capture the behavior here that much of the config file is optional, I've introduced a new type "ConfigFile", where then "Config" is a concrete implementation within the GUI itself after loading the file. I've also made the utils functions more generic as they could work on anything really, not just Config objects.