### PR TITLE
set webpack ts-loader to use build tsconfig

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,10 @@ const webpackConfig = {
     rules: [
       {
         test: /\.tsx?$/,
-        use: 'ts-loader',
+        use: {
+          loader: 'ts-loader',
+          options: { configFile: 'tsconfig.build.json' },
+        },
         exclude: /node_modules/,
       },
       {


### PR DESCRIPTION
This sets the webpack `ts-loader` config to use the `tsconfig.build.json`. This in-turn means we will omit the test directory on building / compiling, which is beneficial to development so that we're not hitting a bunch of type errors or whatever in their as working in src/.