### PR TITLE
do not render table with if no fields or rows

### DIFF
--- a/src/renderer/components/query-result.jsx
+++ b/src/renderer/components/query-result.jsx
@@ -75,10 +75,22 @@ export default class QueryResult extends Component {
       const title = fields[0].name;
       return (
         <Message
-          key={queryIndex}
+          key={`explain-${queryIndex}`}
           preformatted
           title={title}
           message={rows.map((row) => row[title]).join('\n')}
+        />
+      );
+    }
+
+    // Not sure what type of query they ran, but cannot render table, print
+    // generic message.
+    if (fields.length === 0) {
+      return (
+        <Message
+          key={`genericResult-${queryIndex}`}
+          message={`Query executed successfully.`}
+          type="success"
         />
       );
     }


### PR DESCRIPTION
Fixes #573

This fixes the crash where on running a query that's not recognized, but also returns an empty resultset, the app would crash. Now, we'll just print a nice generic "Query success" type message in-lieu of anything better.