### PR TITLE
Upgrade electron to v12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6081,14 +6081,22 @@
       }
     },
     "electron": {
-      "version": "8.5.5",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-8.5.5.tgz",
-      "integrity": "sha512-e355H+tRDial0m+X2v+l+0SnaATAPw4sNjv9qmdk/6MJz/glteVJwVJEnxTjPfEELIJSChrBWDBVpjdDvoBF4Q==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-12.0.1.tgz",
+      "integrity": "sha512-4bTfLSTmuFkMxq3RMyjd8DxuzbxI1Bde879XDrBA4kFWbKhZ3hfXqHXQz3129eCmcLre5odcNsWq7/xzyJilMA==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",
-        "@types/node": "^12.0.12",
+        "@types/node": "^14.6.2",
         "extract-zip": "^1.0.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "14.14.35",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
+          "integrity": "sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==",
+          "dev": true
+        }
       }
     },
     "electron-builder": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     }
   },
   "scripts": {
-    "postinstall": "husky install && electron-builder install-app-deps",
+    "prepare": "husky install",
     "dev": "cross-env NODE_ENV=development concurrently --names \"webpack,electron\" --prefix name \"npm run dev:webpack\" \"npm run dev:electron\"",
     "dev:webpack": "webpack-dev-server --color",
     "dev:electron": "npm run compile:browser && concurrently --kill-others --names \"build,run\" \"npm run compile:browser -- -w\" \"cross-env DEBUG=spawn-auto-restart node scripts/dev-auto-restart.js | bunyan -o short\"",
@@ -127,7 +127,7 @@
     "css-loader": "^4.2.1",
     "csv-stringify": "^5.5.1",
     "dom-helpers": "^5.1.4",
-    "electron": "^8.5.5",
+    "electron": "^12.0.1",
     "electron-builder": "^22.8.0",
     "electron-devtools-installer": "^3.1.1",
     "eslint": "^7.21.0",

--- a/src/browser/window.ts
+++ b/src/browser/window.ts
@@ -29,9 +29,6 @@ export function buildNewWindow(app: App): void {
     minWidth: 512,
     minHeight: 350,
     webPreferences: {
-      nodeIntegration: false, // is default value after Electron v5
-      contextIsolation: true, // protect against prototype pollution
-      enableRemoteModule: false, // turn off remote
       preload: resolve(__dirname, 'preload.js'),
     },
   });


### PR DESCRIPTION
Closes https://github.com/sqlectron/sqlectron-gui/issues/550

Now that we are not using remote anymore for sqlectron-db-core calls, and instead we are using IPC calls and running that in the browser process, which is a node process, there is no need anymore to build native dependencies to Electron anymore. It allow us to upgrade to latest version of Electron, ~which is actually required to fix https://github.com/sqlectron/sqlectron-gui/issues/471 because a new version of ssh2 that supports new auth types depends on Node12.~ ([just noticed Electron v8 is already on Node12](https://www.electronjs.org/releases/stable?version=8&page=5#release-notes-for-v800)).

I tested it running from source and a compiled version for Mac, and both worked fine with MySQL and Sqlite databases.

PS: It is pointing to ipc branch because that has not been merged yet, I am going to point it to master once that has been merged.