### PR TITLE
Fix centering of cursor in react-select inputs

### DIFF
--- a/src/renderer/components/override-select.css
+++ b/src/renderer/components/override-select.css
@@ -1,6 +1,8 @@
 .Select-input input {
   padding: 0 !important;
   border: 0 !important;
+  vertical-align: middle;
+  height: 100%;
 }
 
 .error .Select .Select-control {


### PR DESCRIPTION
When using the `react-select` inputs, the cursor was not centered within the input, rather it was at the top of the box, which just looked odd. This fixes that, so that the cursor now appears properly vertically centered.