### PR TITLE
remove unused sqlectron-db-core exports

### DIFF
--- a/src/browser/core/utils.ts
+++ b/src/browser/core/utils.ts
@@ -6,13 +6,7 @@ import envPaths from 'env-paths';
 
 import { readFile, resolveHomePathToAbsolute } from 'sqlectron-db-core/utils';
 
-export {
-  createCancelablePromise,
-  getPort,
-  readFile,
-  resolveHomePathToAbsolute,
-  versionCompare,
-} from 'sqlectron-db-core/utils';
+export { resolveHomePathToAbsolute } from 'sqlectron-db-core/utils';
 
 let configPath = '';
 

--- a/test/browser/test.utils.ts
+++ b/test/browser/test.utils.ts
@@ -1,29 +1,8 @@
 import { expect } from 'chai';
 import { join } from 'path';
-import { getConfigPath, versionCompare } from '../../src/browser/core/utils';
+import { getConfigPath } from '../../src/browser/core/utils';
 
 describe('utils', () => {
-  describe('.versionCompare', () => {
-    [
-      ['8.0.2', '8.0.1', 1],
-      ['8.0.2', '8.0.3', -1],
-      ['8.0.2.', '8.1', -1],
-      ['8.0.2', '8', 0],
-      ['8.0', '8', 0],
-      ['8', '8', 0],
-      ['8', '8.0.2', 0],
-      ['8', '8.0', 0],
-      ['8.0.2', '12.3', -1],
-      ['12.3', '8', 1],
-      ['12', '8', 1],
-      ['8', '12', -1],
-    ].forEach(([versionA, versionB, expected]) => {
-      it(`.versionCompare('${versionA}', '${versionB}') === ${expected}`, () => {
-        expect(versionCompare(versionA as string, versionB as string)).to.be.eql(expected);
-      });
-    });
-  });
-
   describe('.getConfigPath', () => {
     describe('use of SQLECTRON_HOME', () => {
       let env;


### PR DESCRIPTION
These are unused elsewhere in the app. They only existed within sqlectron-core to maintain backwards compatibility, but that's no longer necessary as it's been merged into the gui itself.