### PR TITLE
Allow unsafe-eval CSP for jointjs

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -105,7 +105,7 @@ const webpackConfig = {
       {
         'base-uri': "'self'",
         'object-src': "'none'",
-        'script-src': ["'self'"],
+        'script-src': ["'unsafe-eval'", "'self'"],
         'style-src': ["'unsafe-inline'", "'self'"],
       },
       {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -105,6 +105,7 @@ const webpackConfig = {
       {
         'base-uri': "'self'",
         'object-src': "'none'",
+        // unsafe-eval should be removed once JointJS is upgraded to 3.x
         'script-src': ["'unsafe-eval'", "'self'"],
         'style-src': ["'unsafe-inline'", "'self'"],
       },


### PR DESCRIPTION
"Generate Database Diagram" was broken on the inclusion of a CSP (#623) as it requires the `unsafe-eval` policy. This policy is not recommended for security reasons, but is necessary until we can upgrade to jointjs (#533). Given that we do not load external webpages, the risk here is somewhat minimal until we can resolve it.

This does re-introduce the warning in #617, but the alternatives are fix the upgrade to JointJS 3.x (which is beyond my time constraints at the moment) or just disable the diagram rendering altogether.