### PR TITLE
Fix server validation not showing errors in the UI

### DIFF
--- a/src/common/types/api.ts
+++ b/src/common/types/api.ts
@@ -1,6 +1,6 @@
 import type { IpcMainInvokeEvent, IpcMainEvent } from 'electron';
 import type { Config } from './config';
-import type { Server } from './server';
+import type { Server, ServerResult } from './server';
 import type { Adapter, QueryRowResult, SchemaFilter, DatabaseFilter } from 'sqlectron-db-core';
 
 export interface MenuOptions {
@@ -101,9 +101,9 @@ export interface SqlectronDB {
 
 export interface SqlectronServers {
   getAll(): Promise<Array<Server>>;
-  add(server: Server, cryptoSecret: string): Promise<Server>;
-  update(server: Server, cryptoSecret: string): Promise<Server>;
-  addOrUpdate(server: Server, cryptoSecret: string): Promise<Server>;
+  add(server: Server, cryptoSecret: string): Promise<ServerResult>;
+  update(server: Server, cryptoSecret: string): Promise<ServerResult>;
+  addOrUpdate(server: Server, cryptoSecret: string): Promise<ServerResult>;
   removeById(id: string): Promise<void>;
   decryptSecrects(server: Server, cryptoSecret: string): Promise<Server>;
 }

--- a/src/common/types/server.ts
+++ b/src/common/types/server.ts
@@ -3,6 +3,11 @@ export interface EncryptedPassword {
   encryptedText: string;
 }
 
+export interface ServerResult {
+  data?: Server;
+  validationErrors?: unknown;
+}
+
 export interface Server {
   id: string;
   name: string;

--- a/src/renderer/actions/servers.ts
+++ b/src/renderer/actions/servers.ts
@@ -49,7 +49,15 @@ export function saveServer({ server, id }: { server: Server; id: string }): Thun
       const cryptoSecret = config.data?.crypto?.secret;
 
       const newServer = Object.assign({}, server, { id });
-      const data = await sqlectron.servers.addOrUpdate(newServer, cryptoSecret as string);
+      const { data, validationErrors } = await sqlectron.servers.addOrUpdate(
+        newServer,
+        cryptoSecret as string,
+      );
+
+      if (validationErrors) {
+        dispatch({ type: SAVE_SERVER_FAILURE, error: { validationErrors } });
+        return;
+      }
 
       dispatch({
         type: SAVE_SERVER_SUCCESS,
@@ -90,7 +98,15 @@ export function duplicateServer({ server }: { server: Server }): ThunkResult<voi
       const { config } = getState();
       const cryptoSecret = config.data?.crypto?.secret;
 
-      const data = await sqlectron.servers.addOrUpdate(duplicated, cryptoSecret as string);
+      const { data, validationErrors } = await sqlectron.servers.addOrUpdate(
+        duplicated,
+        cryptoSecret as string,
+      );
+
+      if (validationErrors) {
+        dispatch({ type: SAVE_SERVER_FAILURE, error: { validationErrors } });
+        return;
+      }
 
       dispatch({
         type: DUPLICATE_SERVER_SUCCESS,


### PR DESCRIPTION
Will fix https://github.com/sqlectron/sqlectron-gui/issues/630

Because of the issue described on https://github.com/sqlectron/sqlectron-gui/issues/630, we cannot pass custom properties through the error object anymore. As far as I know, only the server validations suffer from this problem.