### PR TITLE
Improve ConnectionString usage

### DIFF
--- a/src/renderer/components/server-modal-form.jsx
+++ b/src/renderer/components/server-modal-form.jsx
@@ -95,10 +95,7 @@ export default class ServerModalForm extends Component {
     try {
       const data = { ...currentState, ...newState };
       const clientConfig = DB_CLIENTS.find((entry) => entry.key === data.client);
-
-      if (data.password && !data.showPlainPassword) {
-        data.password = data.password.replace(/./g, '*');
-      }
+      const passwordHash = data.showPlainPassword ? false : '*';
 
       const conn = new ConnectionString(null, {
         protocol: clientConfig ? clientConfig.protocol : '',
@@ -113,7 +110,7 @@ export default class ServerModalForm extends Component {
         ],
       });
 
-      return conn.toString();
+      return conn.toString({passwordHash});
     } catch (err) {
       // Ignore error, it just means the data is not ready to be parsed into the URI format yet
       return '';

--- a/src/renderer/components/server-modal-form.jsx
+++ b/src/renderer/components/server-modal-form.jsx
@@ -110,7 +110,7 @@ export default class ServerModalForm extends Component {
         ],
       });
 
-      return conn.toString({passwordHash});
+      return conn.toString({ passwordHash });
     } catch (err) {
       // Ignore error, it just means the data is not ready to be parsed into the URI format yet
       return '';

--- a/src/renderer/components/server-modal-form.jsx
+++ b/src/renderer/components/server-modal-form.jsx
@@ -174,8 +174,8 @@ export default class ServerModalForm extends Component {
       set(newState, 'user', data.user);
       set(newState, 'password', data.password);
       set(newState, 'database', data.path && data.path[0]);
-      set(newState, 'host', data.hosts && data.hosts[0].name);
-      set(newState, 'port', data.hosts && data.hosts[0].port);
+      set(newState, 'host', data.hostname);
+      set(newState, 'port', data.port);
     } catch (err) {
       // Ignore error, it just means the data is not ready to be parsed from the URI format yet
       return;


### PR DESCRIPTION
As a follow-up [to this](https://github.com/sqlectron/sqlectron-gui/pull/625), from the author of [connection-string] ;)

* Safer and simpler way to access the first host details. See [Virtual Properties](https://github.com/vitaly-t/connection-string#virtual-properties).

* The initial code tried to re-implement `passwordHash` option that [connection-string] supports. It also changes the default `#` symbol to `*` instead, to keep it consistent with how original code worked.

[connection-string]:https://github.com/vitaly-t/connection-string
