### PR TITLE
Fix query configurations from file

### DIFF
--- a/src/renderer/actions/connections.ts
+++ b/src/renderer/actions/connections.ts
@@ -20,7 +20,7 @@ export function getDatabaseByQueryID(state: ApplicationState): string {
     throw new Error('There is no server available');
   }
 
-  const currentQuery = state.queries.queriesById[state.queries.currentQueryId as string];
+  const currentQuery = state.queries.queriesById[state.queries.currentQueryId as number];
 
   return currentQuery ? currentQuery.database : '';
 }
@@ -49,8 +49,8 @@ export function connect(
         isConnected = false;
       }
 
-      const { config } = getState();
-      const cryptoSecret = config.data?.crypto?.secret;
+      const config = getState().config.data;
+      const cryptoSecret = config?.crypto?.secret;
 
       const servers = await sqlectron.servers.getAll();
       server = servers.find((srv) => srv.id === id);

--- a/src/renderer/actions/queries.ts
+++ b/src/renderer/actions/queries.ts
@@ -305,7 +305,7 @@ function stringifyResultToCSV(origRows: [], delimiter: string): Promise<string> 
 }
 
 function getCurrentQuery(state: ApplicationState): Query {
-  return state.queries.queriesById[state.queries.currentQueryId as string];
+  return state.queries.queriesById[state.queries.currentQueryId as number];
 }
 
 function needNewQuery(

--- a/src/renderer/reducers/connections.ts
+++ b/src/renderer/reducers/connections.ts
@@ -3,12 +3,15 @@ import * as types from '../actions/connections';
 import * as serverTypes from '../actions/servers';
 import { DB_CLIENTS } from '../api';
 import { Server } from '../../common/types/server';
+import { Config as ConfigType } from '../../common/types/config';
 
 export interface ConnectionAction extends Action {
   type: string;
   error: Error;
   server: Server;
   database: string;
+  reconnecting: boolean;
+  config?: ConfigType;
 }
 
 export interface ConnectionState {

--- a/src/renderer/reducers/queries.ts
+++ b/src/renderer/reducers/queries.ts
@@ -16,7 +16,7 @@ export interface Query {
   results: null | [];
   error: null | Error;
   copied: null | boolean;
-  resultItemsPerPage: [];
+  resultItemsPerPage: number;
 }
 
 export interface QueryAction extends Action {
@@ -206,18 +206,22 @@ function addNewQuery(state, action) {
     return state;
   }
 
-  const configItemsPerPage = action.config && action.config.resultItemsPerPage;
-  const itemsPerPage =
-    configItemsPerPage || state.resultItemsPerPage || INITIAL_STATE.resultItemsPerPage;
+  let { enabledAutoComplete, enabledLiveAutoComplete, resultItemsPerPage } = INITIAL_STATE;
 
-  let { enabledAutoComplete } = INITIAL_STATE;
-  if (action.config && action.config.enabledAutoComplete !== undefined) {
-    ({ enabledAutoComplete } = action.config);
+  const config = action.config && action.config.data;
+
+  if (config?.resultItemsPerPage !== undefined) {
+    resultItemsPerPage = config?.resultItemsPerPage;
+  } else if (state.resultItemsPerPage !== undefined) {
+    resultItemsPerPage = state.resultItemsPerPage;
   }
 
-  let { enabledLiveAutoComplete } = INITIAL_STATE;
-  if (action.config && action.config.enabledLiveAutoComplete !== undefined) {
-    ({ enabledLiveAutoComplete } = action.config);
+  if (config?.enabledAutoComplete !== undefined) {
+    enabledAutoComplete = config?.enabledAutoComplete;
+  }
+
+  if (config?.enabledLiveAutoComplete !== undefined) {
+    enabledLiveAutoComplete = config?.enabledLiveAutoComplete;
   }
 
   const newId = state.lastCreatedId + 1;
@@ -235,14 +239,14 @@ function addNewQuery(state, action) {
     results: null,
     error: null,
     copied: null,
-    resultItemsPerPage: itemsPerPage,
+    resultItemsPerPage,
   };
 
   return {
     ...state,
     lastCreatedId: newQuery.id,
     currentQueryId: newQuery.id,
-    resultItemsPerPage: itemsPerPage,
+    resultItemsPerPage,
     enabledAutoComplete,
     enabledLiveAutoComplete,
     queryIds: [...state.queryIds, newQuery.id],


### PR DESCRIPTION
Will fix https://github.com/sqlectron/sqlectron-gui/issues/643 and https://github.com/sqlectron/sqlectron-gui/issues/319.

It was accessing the configuration properties directly from `action.config`, but the configuration data is actually at `action.config.data`.