### PR TITLE
Remove Webpack os fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12871,9 +12871,9 @@
       "dev": true
     },
     "connection-string": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/connection-string/-/connection-string-4.3.2.tgz",
-      "integrity": "sha512-t5prDovbYDHeYbdpwRLrEXkFQwqcL04YnfH9Fzisv2yRovPvHE80jMlIybpwKhUlz+MRuOSD2q3+DEaMlNIg9g=="
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/connection-string/-/connection-string-4.3.4.tgz",
+      "integrity": "sha512-WsdoDTkPTFS9/kUKtZmtthG0/jSxqg4YW7tlO6AB24tvxK5UTwqspNxJpK4L+fdIV9fryexZYLOxG9KxVfDLHg=="
     },
     "console-browserify": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@babel/core": "^7.13.1",
     "axios": "^0.21.1",
     "bunyan": "^1.8.5",
-    "connection-string": "^4.3.2",
+    "connection-string": "^4.3.4",
     "core-js": "^3.6.5",
     "electron-devtools-installer": "^3.1.1",
     "env-paths": "^1.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,9 +22,6 @@ const webpackConfig = {
     extensions: ['.js', '.jsx', '.ts', '.tsx'],
     modules: ['node_modules', 'src/renderer'],
     fallback: {
-      // Configuration required for the connection-string module
-      // TODO: https://github.com/sqlectron/sqlectron-gui/issues/656
-      os: false,
       // Configuration required for the csv-stringify module
       // TODO: https://github.com/sqlectron/sqlectron-gui/issues/655
       stream: require.resolve('stream-browserify'),


### PR DESCRIPTION
Will close https://github.com/sqlectron/sqlectron-gui/issues/656.

I updated connection-string to not depend on the `os` module anymore for browser consumers.
I also noticed another issue wasn't really caused by connection-string module, so I created a new ticket for that.