### PR TITLE
Enable no-unused-vars lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,7 +44,6 @@ module.exports = {
         $: true,
       },
       rules: {
-        'no-unused-vars': 'off',
         camelcase: [
           'error',
           {
@@ -107,7 +106,6 @@ module.exports = {
       },
       plugins: ['prettier', '@typescript-eslint'],
       rules: {
-        'no-unused-vars': 'off',
         'react/prop-types': 'off',
         '@typescript-eslint/ban-ts-comment': 'off',
         '@typescript-eslint/no-explicit-any': 'off',
@@ -140,7 +138,6 @@ module.exports = {
       },
       plugins: ['prettier', '@typescript-eslint'],
       rules: {
-        'no-unused-vars': 'off',
         '@typescript-eslint/ban-ts-comment': 'off',
         '@typescript-eslint/no-explicit-any': 'off',
       },
@@ -166,7 +163,6 @@ module.exports = {
       },
       plugins: ['prettier', '@typescript-eslint'],
       rules: {
-        'no-unused-vars': 'off',
         '@typescript-eslint/ban-ts-comment': 'off',
         '@typescript-eslint/no-explicit-any': 'off',
       },
@@ -190,7 +186,6 @@ module.exports = {
       },
       plugins: ['prettier', '@typescript-eslint'],
       rules: {
-        'no-unused-vars': 'off',
         '@typescript-eslint/ban-ts-comment': 'off',
         '@typescript-eslint/no-explicit-any': 'off',
         '@typescript-eslint/no-non-null-assertion': 'off',

--- a/src/renderer/components/database-item.jsx
+++ b/src/renderer/components/database-item.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { sqlectron, DB_CLIENTS } from '../api';
+import { DB_CLIENTS } from '../api';
 import CollapseIcon from './collapse-icon';
 import TableSubmenu from './table-submenu';
 import * as eventKeys from '../../common/event';

--- a/src/renderer/components/database-list-item.jsx
+++ b/src/renderer/components/database-list-item.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { sqlectron } from '../api';
 import DatabaseListItemMetatada from './database-list-item-metadata';
 import DatabaseFilter from './database-filter';
 import * as eventKeys from '../../common/event';

--- a/src/renderer/components/query-result-table-cell.jsx
+++ b/src/renderer/components/query-result-table-cell.jsx
@@ -1,5 +1,4 @@
 import isPlainObject from 'lodash.isplainobject';
-import { sqlectron } from '../api';
 import classNames from 'classnames';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';

--- a/src/renderer/containers/query-browser.jsx
+++ b/src/renderer/containers/query-browser.jsx
@@ -28,7 +28,6 @@ import Footer from '../components/footer';
 import Query from '../components/query';
 import Loader from '../components/loader';
 import PromptModal from '../components/prompt-modal';
-import { sqlectron } from '../api';
 import * as eventKeys from '../../common/event';
 import { requireClientLogo } from '../components/require-context';
 import MenuHandler from '../utils/menu';


### PR DESCRIPTION
Will close https://github.com/sqlectron/sqlectron-gui/issues/665

I think `no-unused-vars` was turned off when we were moving to typescript and also moving to IPC handlers. There were some variables nice to keep around while not using them during that refactoring. But that refactoring is done and we can enable it back once again.