### PR TITLE
Bump version to 1.37.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqlectron",
-  "version": "1.36.0",
+  "version": "1.37.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sqlectron",
-      "version": "1.36.0",
+      "version": "1.37.0",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.14.3",
@@ -8964,8 +8964,7 @@
     },
     "node_modules/@storybook/core-common/node_modules/watchpack/chokidar2": {
       "version": "2.0.0",
-      "dev": true,
-      "optional": true,
+      "extraneous": true,
       "dependencies": {
         "chokidar": "^2.1.8"
       },
@@ -9728,8 +9727,7 @@
     },
     "node_modules/@storybook/core-server/node_modules/watchpack/chokidar2": {
       "version": "2.0.0",
-      "dev": true,
-      "optional": true,
+      "extraneous": true,
       "dependencies": {
         "chokidar": "^2.1.8"
       },
@@ -11239,8 +11237,7 @@
     },
     "node_modules/@storybook/manager-webpack4/node_modules/watchpack/chokidar2": {
       "version": "2.0.0",
-      "dev": true,
-      "optional": true,
+      "extraneous": true,
       "dependencies": {
         "chokidar": "^2.1.8"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlectron",
-  "version": "1.36.0",
+  "version": "1.37.0",
   "description": "A simple and lightweight SQL client with cross database and platform support",
   "author": {
     "name": "The Sqlectron Team",


### PR DESCRIPTION
## Features

* Added support for using connection URI in server form
* Added menu item / keyboard shortcut to auto-format queries in editor

## Bug Fixes

* Fixed running sqlectron with `NODE_ENV=development` set
* Fix server validation not showing errors in the UI
* Fixed color of text in server list when using dark mode
