### PR TITLE
Update version of npm used in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,6 @@
 name: Build
 
-on:
-  push:
-    branches: [ '*' ]
-  pull_request:
-    branches: [ '*' ]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -27,9 +23,13 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Use Node.js ${{ env.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ env.node-version }}
+        cache: npm
+    
+    # Version of npm that comes in 14.x is npm@6
+    - run: npm i -g npm@7
 
     - run: npm ci
 


### PR DESCRIPTION
npm is crashing in #683, probably because it's using npm@6 and the package-lock.json expects npm@7.