### PR TITLE
Fixed bug where switching tab causes loss of focus on editor

### DIFF
--- a/src/renderer/components/query.jsx
+++ b/src/renderer/components/query.jsx
@@ -144,8 +144,9 @@ export default class Query extends Component {
   }
 
   componentDidUpdate() {
+    this.refs.queryBoxTextarea.editor.focus();
+
     if (this.props.query.isExecuting && this.props.query.isDefaultSelect) {
-      this.refs.queryBoxTextarea.editor.focus();
       window.scrollTo(0, 0);
     }
   }


### PR DESCRIPTION
### Problem 
Currently if you have multiple tabs, switching to other tab does not automatically focus on the ace editor (used for query). Though  the editor itself has a caret indicator saying it's focused on. So it is kind of confusing.

I checked the code and found that there is a `autoFocus={true}` property set on the react-ace, but it's not working properly when switching tab.

# Screenshots
![image](https://user-images.githubusercontent.com/3792401/150440362-b72ac49d-719c-4636-bd9b-4fd9def79f9c.png)

Notice the caret at the end of the select statement
![image](https://user-images.githubusercontent.com/3792401/150440438-1b3f83ae-8843-4c4f-9927-15b51490e393.png)

