### PR TITLE
Improve logic for query editor focusing

### DIFF
--- a/src/renderer/components/query.jsx
+++ b/src/renderer/components/query.jsx
@@ -45,6 +45,7 @@ export default class Query extends Component {
     allowCancel: PropTypes.bool.isRequired,
     config: PropTypes.object.isRequired,
     query: PropTypes.object.isRequired,
+    isCurrentQuery: PropTypes.bool.isRequired,
     enabledAutoComplete: PropTypes.bool.isRequired,
     enabledLiveAutoComplete: PropTypes.bool.isRequired,
     databases: PropTypes.array,
@@ -95,6 +96,8 @@ export default class Query extends Component {
     this.menuHandler.setMenus({
       [BROWSER_MENU_EDITOR_FORMAT]: () => this.refs.queryBoxTextarea.editor.execCommand('format'),
     });
+
+    this.refs.queryBoxTextarea.editor.focus();
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {
@@ -143,8 +146,10 @@ export default class Query extends Component {
     );
   }
 
-  componentDidUpdate() {
-    this.refs.queryBoxTextarea.editor.focus();
+  componentDidUpdate(prevProps) {
+    if (prevProps.isCurrentQuery !== this.props.isCurrentQuery && this.props.isCurrentQuery) {
+      this.refs.queryBoxTextarea.editor.focus();
+    }
 
     if (this.props.query.isExecuting && this.props.query.isDefaultSelect) {
       window.scrollTo(0, 0);

--- a/src/renderer/containers/query-browser.jsx
+++ b/src/renderer/containers/query-browser.jsx
@@ -541,6 +541,7 @@ class QueryBrowserContainer extends Component {
             client={connections.server.client}
             allowCancel={allowCancel}
             query={query}
+            isCurrentQuery={query.id === queries.currentQueryId}
             enabledAutoComplete={queries.enabledAutoComplete}
             enabledLiveAutoComplete={queries.enabledLiveAutoComplete}
             database={currentDB}


### PR DESCRIPTION
#687 improved things so that changing tabs would focus the editor. Unfortunately, this broke using the database filter input, but also creating a new tab would not have the editor focused.

This PR fixes it so that only changing tabs affects editor focus, as well as focusing when opening a new tab.