### PR TITLE
Fix spurious sqlite e2e test failure

### DIFF
--- a/test/e2e/test.sqlite.ts
+++ b/test/e2e/test.sqlite.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import sqlite3 from 'sqlite3';
 
 import helper from './helper';
+import { ElectronApplication, Page } from 'playwright';
 
 const BASE_PATH = path.join(__dirname, '../fixtures/sqlite');
 const DB_PATH = path.join(BASE_PATH, 'test.db');
@@ -40,8 +41,8 @@ function setupDB() {
 
 describe('Sqlite', function () {
   let db;
-  let app;
-  let mainWindow;
+  let app: ElectronApplication;
+  let mainWindow: Page;
 
   before(async () => {
     db = setupDB();
@@ -69,6 +70,9 @@ describe('Sqlite', function () {
     await helper.expectToEqualText(mainWindow, '#server-list .attached.button', 'Connect');
 
     const btnConnect = await mainWindow.$('#server-list .attached.button');
+    if (!btnConnect) {
+      expect.fail('Could not find connect button');
+    }
     // TODO: replace dispatchEvent('click') with the click method when we upgrade the electron app.
     // https://github.com/microsoft/playwright/issues/1042
     await btnConnect.dispatchEvent('click');
@@ -80,7 +84,12 @@ describe('Sqlite', function () {
 
     // Clicks in the table to run default select query
     const btnTable = await mainWindow.$('#sidebar .item-Table span');
+    if (!btnTable) {
+      expect.fail('Could not find table button');
+    }
     await btnTable.dispatchEvent('click');
+
+    await mainWindow.waitForSelector('.react-tabs__tab-panel #query-result');
 
     // Set default query and automatically executes it
     await helper.expectToEqualText(


### PR DESCRIPTION
When running `test:e2e`, I was finding that the sqlite test was failing some amount of the time on:
```js
    await helper.expectToEqualText(
      mainWindow,
      '.react-tabs__tab-panel--selected .ace_content',
      'SELECT * FROM "document" LIMIT 101',
    );
```

Where the amount of time taken to load the results was _just_ long enough between the prior click and then running this line that it would fail. As we cannot add a timeout on this particular line, easier to add a `waitForSelector` for some other part of the UI that changes (in this case the query results table appearing) to achieve that goal, and improve stability on this test.