### PR TITLE
Update github actions versions, disable ubuntu and macos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         # TODO: upgrade to latest Ubuntu
         # TODO: re-enable macos
-        os: [ubuntu-20.04, windows-latest]
+        os: [ubuntu-22.04, windows-latest]
 
     steps:
     - name: Install Linux Dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,14 +20,14 @@ jobs:
       if: runner.os == 'Linux'
       run: sudo apt-get install libgnome-keyring-dev icnsutils graphicsmagick rpm bsdtar
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Use Node.js ${{ env.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ env.node-version }}
         cache: npm
-    
+
     # Version of npm that comes in 14.x is npm@6
     - run: npm i -g npm@7
 
@@ -54,7 +54,7 @@ jobs:
     - run: npm run dist -- --publish never
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.os }}
         path: dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,9 @@ jobs:
 
     strategy:
       matrix:
-        # TODO: upgrade to latest Ubuntu
+        # TODO: re-enable ubuntu
         # TODO: re-enable macos
-        os: [ubuntu-22.04, windows-latest]
+        os: [windows-latest]
 
     steps:
     - name: Install Linux Dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,8 @@ jobs:
     strategy:
       matrix:
         # TODO: upgrade to latest Ubuntu
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        # TODO: upgrade to latest macOS
+        os: [ubuntu-18.04, macos-12, windows-latest]
 
     steps:
     - name: Install Linux Dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       matrix:
         # TODO: upgrade to latest Ubuntu
-        # TODO: upgrade to latest macOS
-        os: [ubuntu-18.04, macos-12, windows-latest]
+        # TODO: re-enable macos
+        os: [ubuntu-20.04, windows-latest]
 
     steps:
     - name: Install Linux Dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,12 +25,12 @@ jobs:
         sudo apt-get update
         sudo apt-get install libgnome-keyring-dev icnsutils graphicsmagick rpm bsdtar gcc-multilib g++-multilib
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+    - name: Use Node.js ${{ env.node-version }}
+      uses: actions/setup-node@v4
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: ${{ env.node-version }}
 
     - run: npm ci
 


### PR DESCRIPTION
PR updates the version of the various `actions/*` in our GH workflows. The most important was `actions/upload-artifact` which has disabled v3 from running altogether, and so we need to upgrade it to have the workflows run at all again.

PR also disables ubuntu and macos for the moment as it previously pointed at too old a version of both where:

1. `macos-latest` does not have node 14 available
2. `ubuntu-18.04` does not have runners anymore, and using `ubuntu-22.04` fails due to `apt-get install` of dependencies that no longer exist in Ubuntu.

Luckily Windows is still works for CI, so going to rely on that for the time being as can get the others working again (which will be a requirement to make a new release).