### PR TITLE
Allow user to select install location for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,9 @@
         }
       ]
     },
+    "nsis": {
+      "oneClick": false
+    },
     "publish": {
       "provider": "github",
       "releaseType": "release"

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
       ]
     },
     "nsis": {
+      "allowToChangeInstallationDirectory": true,
       "oneClick": false
     },
     "publish": {


### PR DESCRIPTION
Closes #712 

PR makes it so that when installing the windows build, it will now ask if you want to install the application for just your user or all users, and then where you want to install the application. Given that this is a developer focused tool, I think it's fine to have the slightly more complicated install process here.